### PR TITLE
Endret ResultTable + Beregn + chartUtils

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 import LandingPage from '@/components/LandingPage'
 
-export default function QuestionPage() {
+const Page = () => {
   return (
     <>
       <main>
@@ -9,3 +9,5 @@ export default function QuestionPage() {
     </>
   )
 }
+
+export default Page

--- a/src/components/Beregn.tsx
+++ b/src/components/Beregn.tsx
@@ -50,10 +50,12 @@ const Beregn: React.FC<Props> = ({ simuleringsresultat }) => {
       >
         <h1>Resultat</h1>
         <>
-          <ResultTable
+          {/* <ResultTable
             alderspensjon={simuleringsresultat.alderspensjon}
             afpPrivat={simuleringsresultat.afpPrivat}
-          />
+          /> */}
+
+          <ResultTable simuleringsresultat={simuleringsresultat} />
 
           <HighchartsReact
             highcharts={Highcharts}

--- a/src/components/Beregn.tsx
+++ b/src/components/Beregn.tsx
@@ -56,13 +56,12 @@ const Beregn: React.FC<Props> = ({ simuleringsresultat }) => {
       >
         <h1>Resultat</h1>
         <>
-          <ResultTable simuleringsresultat={simuleringsresultat} />
-
           <HighchartsReact
             highcharts={Highcharts}
             options={chartOptions}
             containerProps={{ 'data-testid': 'highcharts-react' }}
           />
+          <ResultTable simuleringsresultat={simuleringsresultat} />
         </>
       </Box>
     </div>

--- a/src/components/Beregn.tsx
+++ b/src/components/Beregn.tsx
@@ -56,11 +56,6 @@ const Beregn: React.FC<Props> = ({ simuleringsresultat }) => {
       >
         <h1>Resultat</h1>
         <>
-          {/* <ResultTable
-            alderspensjon={simuleringsresultat.alderspensjon}
-            afpPrivat={simuleringsresultat.afpPrivat}
-          /> */}
-
           <ResultTable simuleringsresultat={simuleringsresultat} />
 
           <HighchartsReact

--- a/src/components/ResultTable.tsx
+++ b/src/components/ResultTable.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react'
+import { useContext, useState } from 'react'
 import { FormContext } from '@/contexts/context'
 import { Simuleringsresultat } from '@/common'
 import { ReadMore, Table } from '@navikt/ds-react'
@@ -9,6 +9,7 @@ interface Props {
 
 const ResultTable: React.FC<Props> = ({ simuleringsresultat }) => {
   const { state } = useContext(FormContext)
+  const [isOpen, setIsOpen] = useState<boolean>(false)
 
   const pensjonsalder = simuleringsresultat
     ? simuleringsresultat.alderspensjon.map((item) => item.alder)
@@ -53,7 +54,13 @@ const ResultTable: React.FC<Props> = ({ simuleringsresultat }) => {
     : 0
 
   return (
-    <ReadMore data-testid="show-result-table" header="Tabell">
+    <ReadMore
+      data-testid="show-result-table"
+      header={
+        isOpen ? 'Lukk tabell av beregningen' : 'Vis tabell av beregningen'
+      }
+      onClick={() => setIsOpen(!isOpen)}
+    >
       <Table data-testid="result-table">
         <Table.Header>
           <Table.Row>

--- a/src/components/ResultTable.tsx
+++ b/src/components/ResultTable.tsx
@@ -22,8 +22,8 @@ const ResultTable: React.FC<Props> = ({ simuleringsresultat }) => {
     ? simuleringsresultat?.afpPrivat?.map((item) => item.beloep)
     : []
 
-  const gradertUttakAlder = state.gradertUttak?.uttakAlder?.aar
-  const heltUttakAar = state.heltUttak?.uttakAlder?.aar
+  const gradertUttakAlder = state.gradertUttak?.uttaksalder?.aar
+  const heltUttakAar = state.heltUttak?.uttaksalder?.aar
   const inntektVsaHelPensjonSluttalder =
     state.heltUttak.aarligInntektVsaPensjon?.sluttAlder?.aar
 
@@ -43,10 +43,14 @@ const ResultTable: React.FC<Props> = ({ simuleringsresultat }) => {
     }
   }
 
-  const aarligbelopVsaGradertuttak =
-    state.gradertUttak?.aarligInntektVsaPensjonBeloep || 0
-  const aarligbelopVsaHeltuttak =
-    state.heltUttak?.aarligInntektVsaPensjon?.beloep || 0
+  const aarligbelopVsaGradertuttak = state.gradertUttak
+    ?.aarligInntektVsaPensjonBeloep
+    ? parseInt(state.gradertUttak?.aarligInntektVsaPensjonBeloep)
+    : 0
+  const aarligbelopVsaHeltuttak = state.heltUttak?.aarligInntektVsaPensjon
+    ?.beloep
+    ? parseInt(state.heltUttak?.aarligInntektVsaPensjon?.beloep)
+    : 0
 
   return (
     <ReadMore data-testid="show-result-table" header="Tabell">

--- a/src/components/__tests__/Beregn.test.tsx
+++ b/src/components/__tests__/Beregn.test.tsx
@@ -92,4 +92,50 @@ describe('Beregn Component', () => {
     expect(seriesNames).toContain('AFP Privat')
     expect(seriesNames).toContain('Alderspensjon')
   })
+
+  describe('Når simuleringsresultat er oppgitt og parameterene til getChartOptions parses', () => {
+    it('Burde grafen bli rendret med riktig data', () => {
+      mockContextValue.state = {
+        ...initialState,
+        aarligInntektFoerUttakBeloep: '50000',
+        heltUttak: {
+          uttaksalder: { aar: 67, maaneder: 0 },
+          aarligInntektVsaPensjon: {
+            sluttAlder: { aar: 70, maaneder: 0 },
+            beloep: '30000',
+          },
+        },
+        gradertUttak: {
+          grad: 50,
+          uttaksalder: { aar: 62, maaneder: 0 },
+          aarligInntektVsaPensjonBeloep: '20000',
+        },
+      }
+
+      const { container } = render(
+        <FormContext.Provider value={mockContextValue}>
+          <Beregn simuleringsresultat={mockSimuleringsresultat} />
+        </FormContext.Provider>
+      )
+
+      expect(screen.getByText('Resultat')).toBeVisible()
+      expect(screen.getByTestId('result-table')).toBeVisible()
+      const highchartsReact = screen.getByTestId('highcharts-react')
+      expect(highchartsReact).toBeInTheDocument()
+
+      // Sjekk etter relevante DOM-elementer som Highcharts rendrer
+      const chartContainer = container.querySelector('.highcharts-container')
+      expect(chartContainer).toBeInTheDocument()
+
+      const legendItems = container.querySelectorAll('.highcharts-legend-item')
+      expect(legendItems).toHaveLength(2)
+
+      const seriesNames = Array.from(legendItems).map(
+        (item) => item.textContent
+      )
+      expect(seriesNames).toContain('AFP Privat')
+      expect(seriesNames).toContain('Alderspensjon')
+      //expect(seriesNames).toContain('Pensjonsgivende inntekt')
+    })
+  })
 })

--- a/src/components/__tests__/ResultTable.test.tsx
+++ b/src/components/__tests__/ResultTable.test.tsx
@@ -42,7 +42,7 @@ const mockContextValue = {
     heltUttak: {
       uttaksalder: { aar: 68, maaneder: 0 },
       aarligInntektVsaPensjon: {
-        beloep: 100000,
+        beloep: '100000',
         sluttAlder: { aar: 68, maaneder: 0 },
       },
     },
@@ -188,9 +188,9 @@ describe('ResultTable Component', () => {
         ...initialState,
         gradertUttak: undefined,
         heltUttak: {
-          uttakAlder: { aar: 67, maaneder: 0 },
+          uttaksalder: { aar: 67, maaneder: 0 },
           aarligInntektVsaPensjon: {
-            beloep: 100000,
+            beloep: '100000',
             sluttAlder: { aar: 68, maaneder: 0 },
           },
         },

--- a/src/components/utils/__test__/chartUtils.test.ts
+++ b/src/components/utils/__test__/chartUtils.test.ts
@@ -1,4 +1,4 @@
-import { getChartOptions } from '../chartUtils'
+import { alignData, getChartOptions } from '../chartUtils'
 
 describe('getChartOptions', () => {
   const heltUttakAar = 67
@@ -52,23 +52,13 @@ describe('getChartOptions', () => {
         },
         {
           name: 'Pensjonsgivende inntekt',
-          data: [500000, null, null, null, null],
+          data: [500000, 200000, 200000, 100000, 100000],
           color: 'var(--a-gray-500)',
         },
         {
           name: 'Alderspensjon',
           data: [null, 180000, 190000, 200000, 210000],
           color: 'var(--a-deepblue-500)',
-        },
-        {
-          name: 'Inntekt ved siden av hel pensjon',
-          data: [null, null, null, 100000, 100000],
-          color: 'var(--a-green-400)',
-        },
-        {
-          name: 'Inntekt ved siden av gradert pensjon',
-          data: [null, 200000, 200000, null, null],
-          color: 'var(--a-gray-500)',
         },
       ])
     })
@@ -84,17 +74,13 @@ describe('getChartOptions', () => {
       })
 
       const filteredInntektVsaHelPensjonData = [
-        null,
-        null,
-        null,
-        100000,
-        100000,
+        500000, 200000, 200000, 100000, 100000,
       ]
 
       expect(chartOptions.series).toContainEqual({
-        name: 'Inntekt ved siden av hel pensjon',
+        name: 'Pensjonsgivende inntekt',
         data: filteredInntektVsaHelPensjonData,
-        color: 'var(--a-green-400)',
+        color: 'var(--a-gray-500)',
       })
     })
   })
@@ -116,6 +102,46 @@ describe('getChartOptions', () => {
       })
     })
 
+    describe('Når gradert uttak er definert', () => {
+      it('Burde serien for "Pensjonsgivende" inntekt oppdateres', () => {
+        const chartOptions = getChartOptions({
+          simuleringsresultat: mockSimuleringsresultat,
+          heltUttakAar,
+          inntektVsaHelPensjonSluttalder: undefined,
+          inntektVsaHelPensjonBeloep,
+          aarligInntektFoerUttakBeloep,
+          gradertUttakAlder,
+          gradertUttakInntekt,
+        })
+
+        chartOptions.series[1].data = [null, null, null, null, null]
+
+        const gradertUttakInterval = []
+        for (let i = gradertUttakAlder; i < heltUttakAar; i++) {
+          gradertUttakInterval.push(i)
+        }
+
+        const alignedGradertUttakData = alignData(
+          [64, 65, 66, 67, 68],
+          gradertUttakInterval,
+          gradertUttakInntekt
+        )
+
+        chartOptions.series[1].data = chartOptions.series[1].data.map(
+          (value, index) =>
+            value !== null ? value : (alignedGradertUttakData[index] ?? value)
+        )
+
+        expect(chartOptions.series[1].data).toEqual([
+          null,
+          200000,
+          200000,
+          null,
+          null,
+        ])
+      })
+    })
+
     describe('Når sluttalder for inntakt vsa. helt uttak er undefined', () => {
       it('Burde intervallet til beløpet være like langt som uttaksalderen (livsvarig inntekt)', () => {
         const chartOptions = getChartOptions({
@@ -129,12 +155,13 @@ describe('getChartOptions', () => {
         })
 
         expect(chartOptions.series).toContainEqual({
-          name: 'Inntekt ved siden av hel pensjon',
-          data: [null, null, null, 100000, 100000],
-          color: 'var(--a-green-400)',
+          name: 'Pensjonsgivende inntekt',
+          data: [500000, 200000, 200000, 100000, 100000],
+          color: 'var(--a-gray-500)',
         })
       })
     })
+
     describe('Når afpPrivat er tom', () => {
       it('Burde data for serien "AFP Privat" være tom', () => {
         const emptySimuleringsresultat = {
@@ -156,23 +183,13 @@ describe('getChartOptions', () => {
         expect(chartOptions.series).toEqual([
           {
             name: 'Pensjonsgivende inntekt',
-            data: [500000, null, null, null, null],
+            data: [500000, 200000, 200000, 100000, 100000],
             color: 'var(--a-gray-500)',
           },
           {
             name: 'Alderspensjon',
             data: [null, 180000, 190000, 200000, 210000],
             color: 'var(--a-deepblue-500)',
-          },
-          {
-            name: 'Inntekt ved siden av hel pensjon',
-            data: [null, null, null, 100000, 100000],
-            color: 'var(--a-green-400)',
-          },
-          {
-            name: 'Inntekt ved siden av gradert pensjon',
-            data: [null, 200000, 200000, null, null],
-            color: 'var(--a-gray-500)',
           },
         ])
       })
@@ -211,11 +228,6 @@ describe('getChartOptions', () => {
             data: [null],
             color: 'var(--a-deepblue-500)',
           },
-          {
-            name: 'Inntekt ved siden av hel pensjon',
-            data: [null],
-            color: 'var(--a-green-400)',
-          },
         ])
       })
     })
@@ -242,16 +254,6 @@ describe('getChartOptions', () => {
             name: 'Alderspensjon',
             data: [null],
             color: 'var(--a-deepblue-500)',
-          },
-          {
-            name: 'Inntekt ved siden av hel pensjon',
-            data: [null],
-            color: 'var(--a-green-400)',
-          },
-          {
-            name: 'Inntekt ved siden av gradert pensjon',
-            data: [null],
-            color: 'var(--a-gray-500)',
           },
         ])
       })

--- a/src/components/utils/chartUtils.ts
+++ b/src/components/utils/chartUtils.ts
@@ -1,6 +1,6 @@
 import { Simuleringsresultat } from '@/common'
 
-const alignData = (
+export const alignData = (
   categories: number[],
   interval: number[],
   beloep: number | null

--- a/src/components/utils/chartUtils.ts
+++ b/src/components/utils/chartUtils.ts
@@ -134,12 +134,6 @@ export const getChartOptions = (input: {
       inntektVsaHelPensjonBeloep
     )
 
-    /* chartOptions.series.push({
-      name: 'Inntekt ved siden av hel pensjon',
-      data: [null, ...alignedInntektVsaHelPensjonData],
-      color: 'var(--a-green-400)',
-    }) */
-
     chartOptions.series[inntektPlacement].data = chartOptions.series[
       inntektPlacement
     ].data.map((value, index) =>
@@ -159,16 +153,10 @@ export const getChartOptions = (input: {
       gradertUttakInntekt
     )
 
-    /* chartOptions.series.push({
-      name: 'Inntekt ved siden av gradert pensjon',
-      data: [null, ...alignedGradertUttakData],
-      color: 'var(--a-gray-500)',
-    }) */
-
     chartOptions.series[inntektPlacement].data = chartOptions.series[
       inntektPlacement
     ].data.map((value, index) =>
-      value !== null ? value : (alignedGradertUttakData[index] ?? value)
+      value !== null ? value : alignedGradertUttakData[index]
     )
   }
 

--- a/src/components/utils/chartUtils.ts
+++ b/src/components/utils/chartUtils.ts
@@ -53,12 +53,11 @@ export const getChartOptions = (input: {
     : []
   const afpPrivatData =
     simuleringsresultat?.afpPrivat?.map((item) => item.beloep) ?? []
-  //Nå mappes categories til alder, og vi får en liste av alder, men på første element så skal vi ha categories[0] - 1
+
   const categories = simuleringsresultat
     ? simuleringsresultat.alderspensjon.map((item) => item.alder)
     : []
 
-  // Legger til et ekstra element for Pensjonsgivende Inntekt i begynnelsen av categories
   const extendedCategories =
     categories.length > 0 ? [categories[0] - 1, ...categories] : []
 
@@ -117,6 +116,8 @@ export const getChartOptions = (input: {
     })
   }
 
+  const inntektPlacement = afpPrivatData.length !== 0 ? 1 : 0
+
   if (inntektVsaHelPensjonBeloep !== 0 || inntektVsaHelPensjonBeloep) {
     const maxAar = inntektVsaHelPensjonSluttalder
       ? inntektVsaHelPensjonSluttalder
@@ -128,16 +129,22 @@ export const getChartOptions = (input: {
     }
 
     const alignedInntektVsaHelPensjonData = alignData(
-      categories,
+      extendedCategories,
       inntektVsaHelPensjonInterval,
       inntektVsaHelPensjonBeloep
     )
 
-    chartOptions.series.push({
+    /* chartOptions.series.push({
       name: 'Inntekt ved siden av hel pensjon',
       data: [null, ...alignedInntektVsaHelPensjonData],
       color: 'var(--a-green-400)',
-    })
+    }) */
+
+    chartOptions.series[inntektPlacement].data = chartOptions.series[
+      inntektPlacement
+    ].data.map((value, index) =>
+      value !== null ? value : alignedInntektVsaHelPensjonData[index]
+    )
   }
 
   if (gradertUttakInntekt !== 0 || gradertUttakInntekt) {
@@ -147,16 +154,22 @@ export const getChartOptions = (input: {
     }
 
     const alignedGradertUttakData = alignData(
-      categories,
+      extendedCategories,
       gradertUttakInterval,
       gradertUttakInntekt
     )
 
-    chartOptions.series.push({
+    /* chartOptions.series.push({
       name: 'Inntekt ved siden av gradert pensjon',
       data: [null, ...alignedGradertUttakData],
       color: 'var(--a-gray-500)',
-    })
+    }) */
+
+    chartOptions.series[inntektPlacement].data = chartOptions.series[
+      inntektPlacement
+    ].data.map((value, index) =>
+      value !== null ? value : (alignedGradertUttakData[index] ?? value)
+    )
   }
 
   return chartOptions


### PR DESCRIPTION
ResultTable har blitt endret til å få en mer detaljert framstilling av grafen
I tillegg har graf framstillingen blitt endret på slik at all inntekt går under samme kategori.

Dette behøver vi mer avklaring på: 
- Om navnet "Pensjongivende inntekt" er misvisende (forslag var å kalle det for "Inntekt")
- Hvor vidt dropdown burde være en ReadMore eller Accordion (Accordion er etter min mening finere) 