### PR TITLE
Dev pek 727 to be in document

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -11,8 +11,6 @@ jobs:
       packages: read
       contents: read
       id-token: write
-    outputs:
-      image: ${{ steps.image-creation.outputs.image }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -55,15 +53,6 @@ jobs:
       - name: Build production application
         if: github.event.inputs.prod == 'true'
         run: npm run build:prod
-
-      - name: Docker create image
-        uses: nais/docker-build-push@v0
-        id: image-creation
-        with:
-          team: pensjonskalkulator
-          dockerfile: .docker/Dockerfile
-          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
-          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
 
   run-unit-tests:
     name: Run unit tests

--- a/src/components/__tests__/Beregn.test.tsx
+++ b/src/components/__tests__/Beregn.test.tsx
@@ -66,7 +66,7 @@ describe('Beregn Component', () => {
       </FormContext.Provider>
     )
 
-    expect(screen.getByText('Mocked ResponseWarning')).toBeInTheDocument()
+    expect(screen.getByText('Mocked ResponseWarning')).toBeVisible()
     expect(screen.queryByText('Beregning')).not.toBeInTheDocument()
   })
 
@@ -80,11 +80,11 @@ describe('Beregn Component', () => {
     expect(screen.getByText('Beregning')).toBeVisible()
     expect(screen.getByTestId('result-table')).toBeVisible()
     const highchartsReact = screen.getByTestId('highcharts-react')
-    expect(highchartsReact).toBeInTheDocument()
+    expect(highchartsReact).toBeVisible()
 
     // Sjekk etter relevante DOM-elementer som Highcharts rendrer
     const chartContainer = container.querySelector('.highcharts-container')
-    expect(chartContainer).toBeInTheDocument()
+    expect(chartContainer).toBeVisible()
 
     const legendItems = container.querySelectorAll('.highcharts-legend-item')
     expect(legendItems).toHaveLength(2)
@@ -122,11 +122,11 @@ describe('Beregn Component', () => {
       expect(screen.getByText('Beregning')).toBeVisible()
       expect(screen.getByTestId('result-table')).toBeVisible()
       const highchartsReact = screen.getByTestId('highcharts-react')
-      expect(highchartsReact).toBeInTheDocument()
+      expect(highchartsReact).toBeVisible()
 
       // Sjekk etter relevante DOM-elementer som Highcharts rendrer
       const chartContainer = container.querySelector('.highcharts-container')
-      expect(chartContainer).toBeInTheDocument()
+      expect(chartContainer).toBeVisible()
 
       const legendItems = container.querySelectorAll('.highcharts-legend-item')
       expect(legendItems).toHaveLength(2)

--- a/src/components/__tests__/FormContainerComponent.test.tsx
+++ b/src/components/__tests__/FormContainerComponent.test.tsx
@@ -26,14 +26,12 @@ describe('FormContainer component', () => {
 
   test('Skal rendre komponenten', () => {
     renderComponent()
-    expect(
-      screen.getByText('Uinnlogget pensjonskalkulator')
-    ).toBeInTheDocument()
+    expect(screen.getByText('Uinnlogget pensjonskalkulator')).toBeVisible()
   })
 
   test('Skal rendre FormProgressComponent med riktige props', () => {
     renderComponent()
-    expect(screen.getByText('Mocked FormProgressComponent')).toBeInTheDocument()
+    expect(screen.getByText('Mocked FormProgressComponent')).toBeVisible()
     expect(FormProgressComponent).toHaveBeenCalledWith(
       {
         totalSteps: defaultProps.totalSteps,
@@ -45,6 +43,6 @@ describe('FormContainer component', () => {
 
   test('Skal rendre det nåværende steget', () => {
     renderComponent()
-    expect(screen.getByText('Mocked Step')).toBeInTheDocument()
+    expect(screen.getByText('Mocked Step')).toBeVisible()
   })
 })

--- a/src/components/__tests__/FormPage.test.tsx
+++ b/src/components/__tests__/FormPage.test.tsx
@@ -33,7 +33,7 @@ describe('FormPage Component', () => {
     })
 
     render(<FormPage />)
-    expect(screen.getByText('Mocked AlderStep')).toBeInTheDocument()
+    expect(screen.getByText('Mocked AlderStep')).toBeVisible()
   })
 
   test('Burde rendre andre steg', () => {
@@ -48,7 +48,7 @@ describe('FormPage Component', () => {
     })
 
     render(<FormPage />)
-    expect(screen.getByText('Mocked UtlandsStep')).toBeInTheDocument()
+    expect(screen.getByText('Mocked UtlandsStep')).toBeVisible()
   })
 
   describe('BeregnPage Component', () => {
@@ -64,7 +64,7 @@ describe('FormPage Component', () => {
       })
 
       render(<FormPage />)
-      expect(screen.getByText('Mocked BeregnPage')).toBeInTheDocument()
+      expect(screen.getByText('Mocked BeregnPage')).toBeVisible()
     })
   })
 })

--- a/src/components/__tests__/FormProgressComponent.test.tsx
+++ b/src/components/__tests__/FormProgressComponent.test.tsx
@@ -20,7 +20,7 @@ describe('FormProgressComponent', () => {
     )
 
     const formProgress = getByTestId('form-progress')
-    expect(formProgress).toBeInTheDocument()
+    expect(formProgress).toBeVisible()
 
     const steps = container.querySelectorAll('li')
     expect(steps).toHaveLength(totalSteps)

--- a/src/components/__tests__/FormWrapper.test.tsx
+++ b/src/components/__tests__/FormWrapper.test.tsx
@@ -16,7 +16,7 @@ describe('FormWrapper', () => {
   })
 
   test('Burde rendre children korrekt', () => {
-    expect(screen.getByText('Child Element')).toBeInTheDocument()
+    expect(screen.getByText('Child Element')).toBeVisible()
   })
 
   test('Burde kalle onSubmit når formen er sendt inn', () => {

--- a/src/components/__tests__/ResponseWarning.test.tsx
+++ b/src/components/__tests__/ResponseWarning.test.tsx
@@ -53,7 +53,7 @@ describe('ResponseWarning Component', () => {
     const error = { ...errorObject, status: status }
     render(<ResponseWarning error={error} />)
     const warningMessage = screen.getByText(errorMessageMock[status])
-    expect(warningMessage).toBeInTheDocument()
+    expect(warningMessage).toBeVisible()
   })
 
   test('Should throw "Error is undefined" if no error is provided', () => {

--- a/src/components/__tests__/ResultTable.test.tsx
+++ b/src/components/__tests__/ResultTable.test.tsx
@@ -60,7 +60,7 @@ describe('ResultTable Component', () => {
       </FormContext.Provider>
     )
     fireEvent.click(screen.getByTestId('show-result-table'))
-    expect(screen.getByTestId('result-table')).toBeInTheDocument()
+    expect(screen.getByTestId('result-table')).toBeVisible()
   })
 
   test('Burde rendre tabell dersom vi ikke har et simuleringsresultat', () => {
@@ -73,7 +73,7 @@ describe('ResultTable Component', () => {
     )
 
     fireEvent.click(screen.getByTestId('show-result-table'))
-    expect(screen.getByTestId('result-table')).toBeInTheDocument()
+    expect(screen.getByTestId('result-table')).toBeVisible()
   })
 
   test('Burde vise riktig antall rows', () => {

--- a/src/components/__tests__/Substep.test.tsx
+++ b/src/components/__tests__/Substep.test.tsx
@@ -9,6 +9,6 @@ describe('Substep', () => {
       </Substep>
     )
 
-    expect(getByText('Child Component')).toBeInTheDocument()
+    expect(getByText('Child Component')).toBeVisible()
   })
 })

--- a/src/components/pages/__tests__/AFPStep.test.tsx
+++ b/src/components/pages/__tests__/AFPStep.test.tsx
@@ -78,7 +78,7 @@ describe('AFPStep Component', () => {
     renderMockedComponent(() => <AFPStep />, context)
     expect(
       screen.getByText('Har du rett til AFP i privat sektor?')
-    ).toBeInTheDocument()
+    ).toBeVisible()
   })
 
   test('Burde gå videre til neste step når skjemaet valideres uten feil', () => {

--- a/src/components/pages/__tests__/AlderStep.test.tsx
+++ b/src/components/pages/__tests__/AlderStep.test.tsx
@@ -98,7 +98,7 @@ describe('AlderStep Component', () => {
     fireEvent.submit(form)
     expect(mockValidateFields).toHaveBeenCalledWith('AlderStep')
     expect(mockGoToNext).not.toHaveBeenCalled()
-    expect(screen.getByText('Dette feltet er påkrevd')).toBeInTheDocument()
+    expect(screen.getByText('Dette feltet er påkrevd')).toBeVisible()
   })
 
   test('Burde ikke ha a11y violations dersom errorFields inneholder noe', async () => {

--- a/src/components/pages/__tests__/BeregnPage.test.tsx
+++ b/src/components/pages/__tests__/BeregnPage.test.tsx
@@ -92,7 +92,7 @@ describe('BeregnPage Component', () => {
         expect(screen.queryByTestId('loader')).not.toBeInTheDocument()
       })
 
-      expect(screen.getByText('Mocked ResponseWarning')).toBeInTheDocument()
+      expect(screen.getByText('Mocked ResponseWarning')).toBeVisible()
     })
 
     test('Når henting av data er vellykket, returneres det child-component med resultat', async () => {

--- a/src/components/pages/__tests__/InntektStep.test.tsx
+++ b/src/components/pages/__tests__/InntektStep.test.tsx
@@ -69,12 +69,12 @@ describe('InntektStep Component', () => {
 
   test('Burde rendre komponenten', () => {
     renderMockedComponent(InntektStep, context)
-    expect(screen.getByText('Inntekt og alderspensjon')).toBeInTheDocument()
+    expect(screen.getByText('Inntekt og alderspensjon')).toBeVisible()
     expect(
       screen.getByLabelText(
         'Hva er din årlige pensjonsgivende inntekt frem til du tar ut pensjon?'
       )
-    ).toBeInTheDocument()
+    ).toBeVisible()
   })
 
   test('Burde gå videre til neste step når skjemaet valideres uten feil', () => {
@@ -201,13 +201,13 @@ describe('InntektStep Component', () => {
           screen.getByText(
             `Fra hvilken alder planlegger du å ta ut 50 % pensjon?`
           )
-        ).toBeInTheDocument()
+        ).toBeVisible()
 
         expect(
           screen.getByText(
             `Hva forventer du å ha i årlig inntekt samtidig som du tar 50 % pensjon?`
           )
-        ).toBeInTheDocument()
+        ).toBeVisible()
       })
 
       test('Burde gradertUttak.uttaksalder.aar endres når bruker velger uttaksalder', () => {
@@ -583,7 +583,7 @@ describe('InntektStep Component', () => {
           screen.getByLabelText(
             'Hva forventer du å ha i årlig inntekt samtidig som du tar ut hel pensjon?'
           )
-        ).toBeInTheDocument()
+        ).toBeVisible()
       })
 
       test('Burde heltUttak.aarligInntektVsaPensjonBeloep endres når bruker angir inntekt ved siden av hel pensjon som er større enn 0', () => {
@@ -684,20 +684,41 @@ describe('InntektStep Component', () => {
 
       describe('Gitt at dropdown for sluttAlder finnes', () => {
         describe('Når sluttAlder er livsvarig', () => {
-          test('Burde ikke input felt for heltUttak.sluttAlder.maaneder vises', () => {
+          test('Burde sluttAlder være undefined', () => {
             renderMockedComponent(InntektStep, {
               ...context,
               state: {
                 ...initialState,
                 harInntektVsaHelPensjon: true,
+                heltUttak: {
+                  uttaksalder: {
+                    aar: 0,
+                    maaneder: null,
+                  },
+                  aarligInntektVsaPensjon: {
+                    beloep: '500000',
+                    sluttAlder: {
+                      aar: 65,
+                      maaneder: 0,
+                    },
+                  },
+                },
               },
             })
 
-            expect(
-              document.getElementById(
-                'heltUttakSluttAlder'
-              ) as HTMLSelectElement
-            ).not.toBeInTheDocument()
+            const ageSelect = screen.getByTestId(
+              'heltUttakSluttAlder'
+            ) as HTMLSelectElement
+            fireEvent.change(ageSelect, { target: { value: 'livsvarig' } })
+            expect(mockHandleFieldChange).toHaveBeenCalledWith(
+              expect.any(Function),
+              'heltUttakSluttAlder'
+            )
+
+            const draft = mockHandleFieldChange.mock.results[0].value
+            expect(draft.heltUttak.aarligInntektVsaPensjon.sluttAlder).toBe(
+              undefined
+            )
           })
         })
 

--- a/src/components/pages/__tests__/SivilstandStep.test.tsx
+++ b/src/components/pages/__tests__/SivilstandStep.test.tsx
@@ -63,7 +63,7 @@ beforeEach(() => {
 describe('SivilstandStep Component', () => {
   test('Burde rendre komponenten', () => {
     renderMockedComponent(() => <SivilstandStep grunnbelop={100000} />, context)
-    expect(screen.getByLabelText('Hva er din sivilstand?')).toBeInTheDocument()
+    expect(screen.getByLabelText('Hva er din sivilstand?')).toBeVisible()
   })
 
   test('Burde gå videre til neste step når skjemaet valideres uten feil', () => {
@@ -169,8 +169,8 @@ describe('SivilstandStep Component', () => {
             sivilstand: 'GIFT',
           },
         })
-        expect(screen.getAllByLabelText('Ja')[0]).toBeInTheDocument()
-        expect(screen.getAllByLabelText('Nei')[0]).toBeInTheDocument()
+        expect(screen.getAllByLabelText('Ja')[0]).toBeVisible()
+        expect(screen.getAllByLabelText('Nei')[0]).toBeVisible()
       })
 
       test('Burde begge radioknapper være unchecked som default', () => {
@@ -223,7 +223,7 @@ describe('SivilstandStep Component', () => {
           screen.getByText(
             /Har din ektefelle, partner eller samboer inntekt større enn 100 000 kr/
           )
-        ).toBeInTheDocument()
+        ).toBeVisible()
       })
 
       test('Burde epsHarInntektOver2G bli rendret riktig med udefinert grunnbelop verdi', () => {
@@ -238,7 +238,7 @@ describe('SivilstandStep Component', () => {
           screen.getByText(
             /Har din ektefelle, partner eller samboer inntekt større enn 2G/
           )
-        ).toBeInTheDocument()
+        ).toBeVisible()
       })
     })
   })

--- a/src/components/pages/__tests__/UtlandsStep.test.tsx
+++ b/src/components/pages/__tests__/UtlandsStep.test.tsx
@@ -71,13 +71,13 @@ describe('UtlandsStep Component', () => {
     renderMockedComponent(UtlandsStep, context)
     expect(
       screen.getByText('Har du bodd eller jobbet utenfor Norge?')
-    ).toBeInTheDocument()
+    ).toBeVisible()
 
     const radioButtonJa = screen.getByLabelText('Ja')
-    expect(radioButtonJa).toBeInTheDocument()
+    expect(radioButtonJa).toBeVisible()
 
     const radioButtonNei = screen.getByLabelText('Nei')
-    expect(radioButtonNei).toBeInTheDocument()
+    expect(radioButtonNei).toBeVisible()
   })
 
   test('Burde gå videre til neste step når skjemaet valideres uten feil', () => {
@@ -166,7 +166,7 @@ describe('UtlandsStep Component', () => {
           screen.getByLabelText(
             'Hvor mange år har du bodd eller jobbet utenfor Norge?'
           )
-        ).toBeInTheDocument()
+        ).toBeVisible()
       })
 
       test('Burde utenlandsAntallAar endres når handleFieldChange kalles på', () => {


### PR DESCRIPTION
toBeInDocument er ikke fjernet i de tilfellene hvor tekst ikke er rendret i DOM'et, altså i de testene hvor vi forsikrer oss om at det ikke blir rendret. 