### PR TITLE
PEK-549 Handle renamed exceptions

### DIFF
--- a/src/common.d.ts
+++ b/src/common.d.ts
@@ -62,9 +62,9 @@ export type Simuleringsresultat =
 export type SimuleringError = components['schemas']['AnonymSimuleringErrorV1']
 
 export type ErrorStatus =
-  | 'PKU222BeregningstjenesteFeiletException'
-  | 'PKU225AvslagVilkarsprovingForLavtTidligUttakException'
-  | 'PKU224AvslagVilkarsprovingForKortTrygdetidException'
+  | 'RegelmotorFeilException'
+  | 'UtilstrekkeligOpptjeningException'
+  | 'UtilstrekkeligTrygdetidException'
   | 'default'
 
 export type ErrorMessages = {

--- a/src/texts/errors.ts
+++ b/src/texts/errors.ts
@@ -1,12 +1,12 @@
 import { ErrorMessages } from '@/common'
 
 export const errors = {
-  PKU222BeregningstjenesteFeiletException:
+  RegelmotorFeilException:
     'Det har oppstått en feil. Vennligst prøv igjen senere.',
-  PKU225AvslagVilkarsprovingForLavtTidligUttakException:
+  UtilstrekkeligOpptjeningException:
     'Opptjeningen din er ikke høy nok til ønsket uttak. Du må øke alderen eller sette ned uttaksgraden.',
-  PKU224AvslagVilkarsprovingForKortTrygdetidException:
-    'Opptjeningen din er ikke høy nok til ønsket uttak. Du må øke alderen eller sette ned uttaksgraden.',
+  UtilstrekkeligTrygdetidException:
+    'Du har for kort trygdetid.',
   default: 'Det har oppstått en feil. Vennligst prøv igjen senere.',
 } as ErrorMessages
 


### PR DESCRIPTION
I forbindelse med at [pensjonskalkulator-backend](https://github.com/navikt/pensjonskalkulator-backend) går over til å bruke [pensjonssimulator](https://github.com/navikt/pensjonssimulator/) istedenfor [PEN](https://github.com/navikt/pensjon-pen) for uinnlogget simulering, er feilhåndteringen endret.
Denne PR gjør at frontend håndterer endrede exception-navn.
