### PR TITLE
TPP-18 Use Chainguard Docker image

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs22-debian12
+FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/node:22
 
 ENV NODE_ENV=production
 ENV TZ="Europe/Oslo"


### PR DESCRIPTION
> I Nav betaler vi for Chainguard images som er minimale images med ekstra sikkerhetstiltak. Her får du distroless images med (nesten alltid) null sårbarheter.

– [Nav Security Playbook: Valg av baseimage](https://sikkerhet.nav.no/docs/sikker-utvikling/baseimages/)