### PR TITLE
fix: patch audit vulnerabilities and refresh Chainguard image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,7 +121,7 @@ jobs:
     needs: [ build ]
     if: |
       github.ref_name == 'main' &&
-      (github.event_name == 'push' || github.event_name == 'schedule')
+      (github.event_name == 'push')
     runs-on: ubuntu-latest
     permissions:
       packages: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,8 +15,10 @@ on:
         description: Deploy to production
         type: boolean
         required: false
+  # Rebuild and redeploy sandbox weekly so Chainguard base image patches are picked up.
+  # GitHub cron uses UTC; 03:00 UTC is 05:00 in Oslo during daylight saving time.
   schedule:
-    - cron: '0 0 * * 1'
+    - cron: '0 3 * * 1'
 
 jobs:
   build:
@@ -114,7 +116,7 @@ jobs:
     needs: [ build ]
     if: |
       github.ref_name == 'main' &&
-      github.event_name == 'push'
+      (github.event_name == 'push' || github.event_name == 'schedule')
     runs-on: ubuntu-latest
     permissions:
       packages: read

--- a/package.json
+++ b/package.json
@@ -78,7 +78,9 @@
     "overrides": {
       "@types/react": "19.1.10",
       "@types/react-dom": "19.1.7",
-      "jsdom>parse5": "^7.1.2"
+      "jsdom>parse5": "^7.1.2",
+      "postcss@<8.5.14": "8.5.14",
+      "ip-address@<=10.1.0": "10.2.0"
     },
     "ignoredBuiltDependencies": [
       "unrs-resolver"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "typecheck": "tsc --noEmit --pretty -p tsconfig.json && tsc --noEmit --pretty -p tsconfig.server.json",
     "lint": "next lint",
     "prettier:fix": "prettier --write '**/*.{cjs,js,jsx,ts,tsx,json}'",
-    "prepare": "husky"
+    "prepare": "if [ -z \"$CI\" ]; then husky; fi"
   },
   "packageManager": "pnpm@10.11.0",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
       "@types/react-dom": "19.1.7",
       "jsdom>parse5": "^7.1.2",
       "postcss@<8.5.14": "8.5.14",
-      "ip-address@<=10.1.0": "10.2.0"
+      "ip-address@<=10.1.0": "10.2.0",
+      "@ungap/structured-clone@<1.3.1": "1.3.1"
     },
     "ignoredBuiltDependencies": [
       "unrs-resolver"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   jsdom>parse5: ^7.1.2
   postcss@<8.5.14: 8.5.14
   ip-address@<=10.1.0: 10.2.0
+  '@ungap/structured-clone@<1.3.1': 1.3.1
 
 importers:
 
@@ -1202,9 +1203,8 @@ packages:
     resolution: {integrity: sha512-+GeGMebMCy0elMNg67LRNoVnUFPIm37iu5CmHESVx56/9Jsfdpsvbv605DQ81Pi/x11IdKUsS5nzgTYbCQU9fg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@ungap/structured-clone@1.3.0':
-    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
-    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
+  '@ungap/structured-clone@1.3.1':
+    resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -5236,7 +5236,7 @@ snapshots:
       '@typescript-eslint/types': 8.41.0
       eslint-visitor-keys: 4.2.1
 
-  '@ungap/structured-clone@1.3.0': {}
+  '@ungap/structured-clone@1.3.1': {}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     optional: true
@@ -7153,7 +7153,7 @@ snapshots:
   jest-worker@30.0.5:
     dependencies:
       '@types/node': 24.3.0
-      '@ungap/structured-clone': 1.3.0
+      '@ungap/structured-clone': 1.3.1
       jest-util: 30.0.5
       merge-stream: 2.0.0
       supports-color: 8.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,8 @@ overrides:
   '@types/react': 19.1.10
   '@types/react-dom': 19.1.7
   jsdom>parse5: ^7.1.2
+  postcss@<8.5.14: 8.5.14
+  ip-address@<=10.1.0: 10.2.0
 
 importers:
 
@@ -777,9 +779,6 @@ packages:
     peerDependencies:
       '@types/react': 19.1.10
       react: '>=17.0.0 || >19.0.0-rc'
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
 
   '@navikt/ds-tokens@7.28.1':
     resolution: {integrity: sha512-6xPQjBuavHe+EUQgdgFxXIl/cPmF028c/PP/KU47iKZGc8NQdCQYr9+wdRc4NRjngRXPi3GQ+2vX3XmdGuRofg==, tarball: https://npm.pkg.github.com/download/@navikt/ds-tokens/7.28.1/b8f8bac92b64d3966d823cc46bb586d0ec059e90}
@@ -792,9 +791,6 @@ packages:
       html-react-parser: '>=5.x'
       jsdom: '>=16.x'
       react: '>=17.x'
-    peerDependenciesMeta:
-      react:
-        optional: true
 
   '@navikt/oasis@3.8.0':
     resolution: {integrity: sha512-5CDsv3wop9eIw2YNBCJRr0w6PwwkoTiHzZQXn1+5YZnsksCkHJAFsfKSbRle6zgsD+XRBnc/TPOP0nvNly7NWg==, tarball: https://npm.pkg.github.com/download/@navikt/oasis/3.8.0/fc6862d934adfbefa382220614af18160688cd1e}
@@ -1208,6 +1204,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -2404,12 +2401,8 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
-    engines: {node: '>= 12'}
-
-  ip-address@9.0.5:
-    resolution: {integrity: sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -2768,9 +2761,6 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
-
-  jsbn@1.1.0:
-    resolution: {integrity: sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==}
 
   jsdom@26.1.0:
     resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
@@ -3280,8 +3270,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -3603,9 +3593,6 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
-
-  sprintf-js@1.1.3:
-    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
   ssri@13.0.1:
     resolution: {integrity: sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==}
@@ -4766,12 +4753,11 @@ snapshots:
       '@floating-ui/react-dom': 2.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@navikt/aksel-icons': 7.28.1
       '@navikt/ds-tokens': 7.28.1
+      '@types/react': 19.1.10
       clsx: 2.1.1
       date-fns: 4.1.0
       react: 19.2.3
       react-day-picker: 9.7.0(react@19.2.3)
-    optionalDependencies:
-      '@types/react': 19.1.10
     transitivePeerDependencies:
       - react-dom
 
@@ -4783,7 +4769,6 @@ snapshots:
       html-react-parser: 5.2.6(@types/react@19.1.10)(react@19.2.3)
       js-cookie: 3.0.5
       jsdom: 29.0.2
-    optionalDependencies:
       react: 19.2.3
 
   '@navikt/oasis@3.8.0':
@@ -6650,12 +6635,7 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.1.0
 
-  ip-address@10.1.0: {}
-
-  ip-address@9.0.5:
-    dependencies:
-      jsbn: 1.1.0
-      sprintf-js: 1.1.3
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -7210,8 +7190,6 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsbn@1.1.0: {}
-
   jsdom@26.1.0:
     dependencies:
       cssstyle: 4.6.0
@@ -7529,7 +7507,7 @@ snapshots:
       '@next/env': 15.5.15
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001731
-      postcss: 8.4.31
+      postcss: 8.5.14
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       styled-jsx: 5.1.6(@babel/core@7.28.0)(react@19.2.3)
@@ -7737,7 +7715,7 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.4.31:
+  postcss@8.5.14:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -8105,7 +8083,7 @@ snapshots:
 
   socks@2.8.7:
     dependencies:
-      ip-address: 10.1.0
+      ip-address: 10.2.0
       smart-buffer: 4.2.0
 
   sort-on@6.1.0:
@@ -8122,8 +8100,6 @@ snapshots:
   source-map@0.6.1: {}
 
   sprintf-js@1.0.3: {}
-
-  sprintf-js@1.1.3: {}
 
   ssri@13.0.1:
     dependencies:
@@ -8429,7 +8405,7 @@ snapshots:
     dependencies:
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6(supports-color@10.1.0)
-      ip-address: 9.0.5
+      ip-address: 10.2.0
       launchdarkly-eventsource: 2.2.0
       make-fetch-happen: 15.0.4
       murmurhash3js: 3.0.1


### PR DESCRIPTION
## Oppsummering

- Legger til pnpm-overrides for `postcss` og `ip-address` for å lukke audit-funn fra `next` og `@navikt/steng-for-regulering`/`unleash-client`.
- Oppdaterer `pnpm-lock.yaml`.
- Oppdaterer eksisterende ukentlig schedule til mandag 03:00 UTC (05:00 Oslo under sommertid).
- Scheduled run bygger nå også nytt Chainguard-basert image og redeployer sandbox, slik at nye baseimage-patcher plukkes opp selv om appen ellers er stille.

## Verifisering

- [x] `pnpm audit` → 0 vulnerabilities
- [x] `pnpm typecheck` feiler på eksisterende Highcharts-testtyping i `src/components/utils/__test__/chartUtils.test.ts`, ikke relatert til dependency-overrides.

## Merknad

CVE-funnene er lukket i lockfile/audit. Typecheck-feilen gjelder `SeriesOptionsType.data` i testkode og bør håndteres separat.
