### PR TITLE
Fix type generation

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -31,22 +31,11 @@ jobs:
           NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
 
-      - name: Fetch openapi backend types
-        run: pnpm exec openapi-typescript ${{ github.event.inputs.prod == 'true' && 'https://www.nav.no/pensjon/kalkulator/v3/api-docs/current' || 'https://staging.ekstern.dev.nav.no/pensjon/kalkulator/v3/api-docs/current' }} -o ./src/types/schema.d.ts
-
-      - name: Format backend scheme
-        run: pnpm format:types
-
       - name: Run lint
         run: pnpm lint
 
-      - name: Build staging application
-        if: github.event.inputs.prod != 'true'
+      - name: Build application
         run: pnpm build
-
-      - name: Build production application
-        if: github.event.inputs.prod == 'true'
-        run: pnpm build:prod
 
   run-unit-tests:
     name: Run unit tests

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,12 +50,6 @@ jobs:
           NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
 
-      - name: Fetch openapi backend types
-        run: pnpm exec openapi-typescript ${{ github.event.inputs.prod == 'true' && 'https://www.nav.no/pensjon/kalkulator/v3/api-docs/current' || 'https://staging.ekstern.dev.nav.no/pensjon/kalkulator/v3/api-docs/current' }} -o ./src/types/schema.d.ts
-
-      - name: Format backend scheme
-        run: pnpm format:types
-
       - name: Run lint
         run: pnpm lint
 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,2 @@
+pnpm generate-types
+git diff --quiet src/types/schema.d.ts || (echo 'ERROR: schema.d.ts was updated. Please commit the changes and push again.' && exit 1)

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "next start",
     "dev": "concurrently -k \"next dev --turbopack\" \"json-server mockdb/db.json --port 3001\"",
     "fetch-dev-types": "openapi-typescript https://pensjonskalkulator-backend.intern.dev.nav.no/v3/api-docs/current -o ./src/types/schema.d.ts",
+    "generate-types": "openapi-typescript https://www.nav.no/pensjon/kalkulator/v3/api-docs/current -o ./src/types/schema.d.ts && pnpm format:types",
     "format:types": "prettier --write ./src/types/schema.d.ts && eslint ./src/types/schema.d.ts --fix",
     "test": "jest",
     "testc": "jest --c",

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -4,7 +4,7 @@
  */
 
 export interface paths {
-    "/api/v8/alderspensjon/simulering": {
+    "/api/v9/alderspensjon/simulering": {
         parameters: {
             query?: never;
             header?: never;
@@ -17,7 +17,27 @@ export interface paths {
          * Simuler alderspensjon
          * @description Lag en prognose for framtidig alderspensjon med støtte for AFP i offentlig sektor. Feltet 'epsHarInntektOver2G' brukes til å angi hvorvidt ektefelle/partner/samboer har inntekt over 2 ganger grunnbeløpet. Dersom simulering med de angitte parametre resulterer i avslag i vilkårsprøvingen, vil responsen inneholde alternative parametre som vil gi et innvilget simuleringsresultat
          */
-        post: operations["simulerAlderspensjonV8"];
+        post: operations["simulerAlderspensjonV9"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v3/tidligste-hel-uttaksalder": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Tidligst mulige uttaksalder ved helt uttak
+         * @description Finn tidligst mulige uttaksalder for innlogget bruker ved helt (100 %) uttak.
+         */
+        post: operations["finnTidligsteHelUttaksalderV3"];
         delete?: never;
         options?: never;
         head?: never;
@@ -44,26 +64,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v2/tidligste-hel-uttaksalder": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Tidligst mulige uttaksalder ved helt uttak
-         * @description Finn tidligst mulige uttaksalder for innlogget bruker ved helt (100 %) uttak.
-         */
-        post: operations["finnTidligsteHelUttaksalderV2"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/api/v2/simuler-oftp": {
         parameters: {
             query?: never;
@@ -74,8 +74,8 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Simuler offentlig tjenestepensjon hos tp-leverandør bruker er medlem av
-         * @description Simulerer offentlig tjenestepensjon hos tp-leverandør som har ansvar for brukers tjenestepensjon
+         * Simuler offentlig tjenestepensjon hos TP-leverandør bruker er medlem av
+         * @description Simulerer offentlig tjenestepensjon hos TP-leverandør som har ansvar for brukers tjenestepensjon
          */
         post: operations["simulerOffentligTjenestepensjonV2"];
         delete?: never;
@@ -84,7 +84,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v2/pensjonsavtaler": {
+    "/api/v2/simuler-oftp/foer-1963": {
         parameters: {
             query?: never;
             header?: never;
@@ -94,50 +94,10 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Hent pensjonsavtaler (versjon 2)
-         * @description Henter pensjonsavtalene til den innloggede/angitte brukeren. I request må verdi av 'maaneder' være 0..11.
+         * Simuler offentlig tjenestepensjon hos TP-leverandør bruker er medlem av
+         * @description Simulerer offentlig tjenestepensjon hos TP-leverandør som har ansvar for brukers tjenestepensjon
          */
-        post: operations["fetchAvtalerV2"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/tidligste-hel-uttaksalder": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Første mulige uttaksalder ved helt uttak
-         * @description Finn første mulige uttaksalder for innlogget bruker ved helt (100 %) uttak. Feltet 'harEps' brukes til å angi om brukeren har ektefelle/partner/samboer eller ei
-         */
-        post: operations["finnTidligsteHelUttaksalderV1"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v1/simuler-oftp": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Simuler offentlig tjenestepensjon hos tp-leverandør bruker er medlem av
-         * @description Simulerer offentlig tjenestepensjon hos tp-leverandør som har ansvar for brukers tjenestepensjon
-         */
-        post: operations["simulerOffentligTjenestepensjonV1"];
+        post: operations["simulerOffentligTjenestepensjonFoer1963V1"];
         delete?: never;
         options?: never;
         head?: never;
@@ -164,6 +124,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/decrypt": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Dekrypter tekst
+         * @description Dekrypterer angitt tekst (typisk brukstilfelle er for fødselsnumre)
+         */
+        post: operations["decrypt"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/alderspensjon/anonym-simulering": {
         parameters: {
             query?: never;
@@ -184,7 +164,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/aldersgrense": {
+    "/api/intern/v1/pensjon/simulering": {
         parameters: {
             query?: never;
             header?: never;
@@ -194,10 +174,110 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Hent nedre aldersgrense og normert pensjonsalder
-         * @description Henter informasjon om aldersgrensene for et årskull.
+         * Simuler pensjon
+         * @description Lager en prognose for framtidig alderspensjon med støtte for AFP.
          */
-        post: operations["aldersgrenserV1"];
+        post: operations["simulerPensjon"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/intern/v1/lagre-simulering": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Lagre simuleringsresultat
+         * @description Lagrer et simuleringsresultat via Skribenten-tjenesten.
+         */
+        post: operations["lagreSimuleringV1"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/intern/v1/eps": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Hent nyligste EPS
+         * @description Henter informasjon om nyligste ektefelle/partner/samboer.
+         */
+        post: operations["nyligsteEps"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/ekstern/v1/pensjon/simulering": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Simuler pensjon
+         * @description Lag en prognose for framtidig alderspensjon med støtte for AFP. Dersom simulering med de angitte parametre resulterer i avslag i vilkårsprøvingen, vil responsen inneholde alternative parametre som vil gi et innvilget simuleringsresultat
+         */
+        post: operations["simulerPensjon_1"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v7/person": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Hent personinformasjon
+         * @description Henter informasjon om personen hvis person-ID er angitt enten i bearer-tokenet eller som fnr-header.
+         */
+        get: operations["person"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v6/person": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Hent personinformasjon
+         * @description Henter informasjon om personen hvis person-ID er angitt enten i bearer-tokenet eller som fnr-header.
+         */
+        get: operations["personV6"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -224,7 +304,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v4/person": {
+    "/api/v3/tpo-livsvarig-offentlig-afp": {
         parameters: {
             query?: never;
             header?: never;
@@ -232,10 +312,10 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Hent personinformasjon
-         * @description Henter informasjon om personen hvis person-ID er angitt enten i bearer-tokenet eller som fnr-header.
+         * Hent løpende livsvarig offentlig AFP
+         * @description Henter detaljer om løpende livsvarig AFP i offentlig sektor for brukeren
          */
-        get: operations["personV4"];
+        get: operations["hentLivsvarigOffentligAfpDetaljerV3"];
         put?: never;
         post?: never;
         delete?: never;
@@ -244,7 +324,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v3/vedtak/loepende-vedtak": {
+    "/api/v2/tpo-livsvarig-offentlig-afp": {
         parameters: {
             query?: never;
             header?: never;
@@ -252,50 +332,10 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Har løpende vedtak
-         * @description Hvorvidt den innloggede brukeren har løpende uføretrygd med uttaksgrad, alderspensjon med uttaksgrad, AFP i privat eller offentlig sektor
+         * Hent løpende livsvarig offentlig AFP
+         * @description Henter detaljer om løpende livsvarig AFP i offentlig sektor for brukeren
          */
-        get: operations["hentLoependeVedtakV3"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v2/vedtak/loepende-vedtak": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Har løpende vedtak
-         * @description Hvorvidt den innloggede brukeren har løpende uføretrygd med uttaksgrad, alderspensjon med uttaksgrad, AFP i privat eller offentlig sektor
-         */
-        get: operations["hentLoependeVedtakV2"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/v2/person": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Hent personinformasjon
-         * @description Henter informasjon om personen hvis person-ID er angitt enten i bearer-tokenet eller som fnr-header.
-         */
-        get: operations["personV2"];
+        get: operations["hentLivsvarigOffentligAfpDetaljer"];
         put?: never;
         post?: never;
         delete?: never;
@@ -316,6 +356,26 @@ export interface paths {
          * @description Eksludering kan skyldes medlemskap i Apotekerforeningen
          */
         get: operations["erEkskludertV2"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/vedtak": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Hent vedtak
+         * @description Henter løpende vedtak om alderspensjon, AFP (i privat og offentlig sektor) og uføretrygd, samt fremtidige alderspensjonsvedtak
+         */
+        get: operations["hentVedtak"];
         put?: never;
         post?: never;
         delete?: never;
@@ -396,6 +456,26 @@ export interface paths {
          * @description Henter liste over land med navn og status som avtaleland. Denne tjenesten er åpen - krever ikke autentisering.
          */
         get: operations["landListe"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/er-apoteker": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Om personen er ekskludert fra å bruke kalkulatoren
+         * @description Eksludering skyldes medlemskap i Apotekerforeningen
+         */
+        get: operations["erApotekerV1"];
         put?: never;
         post?: never;
         delete?: never;
@@ -504,6 +584,66 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/intern/v1/sivilstatus": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Hent nåværende sivilstatus
+         * @description Henter informasjon om nåværende sivilstatus.
+         */
+        get: operations["naavaerendeSivilstatus"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/intern/v1/person": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Hent personinformasjon
+         * @description Henter informasjon om personen hvis person-ID er angitt som fnr-header.
+         */
+        get: operations["personV1"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/intern/v1/enheter": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Hent den ansattes enheter
+         * @description Henter en liste over den innloggede ansattes enheter, dvs. tjenestekontornummer.
+         */
+        get: operations["tjenestekontorEnhetListe"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/inntekt": {
         parameters: {
             query?: never;
@@ -548,125 +688,150 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
-        PersonligSimuleringAlderSpecV8: {
+        PersonligSimuleringAlderSpecV9: {
             /** Format: int32 */
             aar: number;
             /** Format: int32 */
             maaneder: number;
         };
-        PersonligSimuleringGradertUttakSpecV8: {
+        PersonligSimuleringGradertUttakSpecV9: {
             /** Format: int32 */
             grad: number;
-            uttaksalder: components["schemas"]["PersonligSimuleringAlderSpecV8"];
+            uttaksalder: components["schemas"]["PersonligSimuleringAlderSpecV9"];
             /** Format: int32 */
-            aarligInntektVsaPensjonBeloep?: number;
+            aarligInntektVsaPensjonBeloep?: number | null;
         };
-        PersonligSimuleringHeltUttakSpecV8: {
-            uttaksalder: components["schemas"]["PersonligSimuleringAlderSpecV8"];
-            aarligInntektVsaPensjon?: components["schemas"]["PersonligSimuleringInntektSpecV8"];
+        PersonligSimuleringHeltUttakSpecV9: {
+            uttaksalder: components["schemas"]["PersonligSimuleringAlderSpecV9"];
+            aarligInntektVsaPensjon?: components["schemas"]["PersonligSimuleringInntektSpecV9"] | null;
         };
-        PersonligSimuleringInntektSpecV8: {
+        PersonligSimuleringInntektSpecV9: {
             /** Format: int32 */
             beloep: number;
-            sluttAlder: components["schemas"]["PersonligSimuleringAlderSpecV8"];
+            sluttAlder: components["schemas"]["PersonligSimuleringAlderSpecV9"];
         };
-        PersonligSimuleringSpecV8: {
+        PersonligSimuleringInnvilgetLivsvarigOffentligAfpSpecV9: {
+            /** Format: double */
+            aarligBruttoBeloep: number;
+            /** Format: date */
+            uttakFom: string;
+            /** Format: int32 */
+            sistRegulertGrunnbeloep?: number | null;
+        };
+        PersonligSimuleringSpecV9: {
             /** @enum {string} */
-            simuleringstype: "ALDERSPENSJON" | "PRE2025_OFFENTLIG_AFP_ETTERFULGT_AV_ALDERSPENSJON" | "ALDERSPENSJON_MED_AFP_PRIVAT" | "ALDERSPENSJON_MED_AFP_OFFENTLIG_LIVSVARIG" | "ENDRING_ALDERSPENSJON" | "ENDRING_ALDERSPENSJON_MED_AFP_PRIVAT" | "ENDRING_ALDERSPENSJON_MED_AFP_OFFENTLIG_LIVSVARIG";
+            simuleringstype: "ALDERSPENSJON" | "PRE2025_OFFENTLIG_AFP_ETTERFULGT_AV_ALDERSPENSJON" | "ALDERSPENSJON_MED_AFP_PRIVAT" | "ALDERSPENSJON_MED_AFP_OFFENTLIG_LIVSVARIG" | "ALDERSPENSJON_MED_GJENLEVENDERETT" | "ENDRING_ALDERSPENSJON" | "ENDRING_ALDERSPENSJON_MED_AFP_PRIVAT" | "ENDRING_ALDERSPENSJON_MED_AFP_OFFENTLIG_LIVSVARIG" | "ENDRING_ALDERSPENSJON_MED_GJENLEVENDERETT" | "SERVICEBEREGN_AFP";
             /** Format: date */
             foedselsdato: string;
             /** Format: int32 */
-            aarligInntektFoerUttakBeloep?: number;
-            gradertUttak?: components["schemas"]["PersonligSimuleringGradertUttakSpecV8"];
-            heltUttak: components["schemas"]["PersonligSimuleringHeltUttakSpecV8"];
-            utenlandsperiodeListe?: components["schemas"]["PersonligSimuleringUtenlandsperiodeSpecV8"][];
-            /** @enum {string} */
-            sivilstand?: "UNKNOWN" | "UOPPGITT" | "UGIFT" | "GIFT" | "ENKE_ELLER_ENKEMANN" | "SKILT" | "SEPARERT" | "REGISTRERT_PARTNER" | "SEPARERT_PARTNER" | "SKILT_PARTNER" | "GJENLEVENDE_PARTNER" | "SAMBOER";
-            epsHarInntektOver2G: boolean;
-            epsHarPensjon: boolean;
-            afpInntektMaanedFoerUttak?: boolean;
-            /** @enum {string} */
-            afpOrdning?: "AFPKOM" | "AFPSTAT" | "FINANS" | "KONV_K" | "KONV_O" | "LONHO" | "NAVO";
+            aarligInntektFoerUttakBeloep?: number | null;
+            gradertUttak?: components["schemas"]["PersonligSimuleringGradertUttakSpecV9"] | null;
+            heltUttak: components["schemas"]["PersonligSimuleringHeltUttakSpecV9"];
+            utenlandsperiodeListe?: components["schemas"]["PersonligSimuleringUtenlandsperiodeSpecV9"][] | null;
+            /** @enum {string|null} */
+            sivilstand?: "UNKNOWN" | "UOPPGITT" | "UGIFT" | "GIFT" | "ENKE_ELLER_ENKEMANN" | "SKILT" | "SEPARERT" | "REGISTRERT_PARTNER" | "SEPARERT_PARTNER" | "SKILT_PARTNER" | "GJENLEVENDE_PARTNER" | "SAMBOER" | null;
+            epsHarInntektOver2G?: boolean | null;
+            epsHarPensjon?: boolean | null;
+            afpInntektMaanedFoerUttak?: boolean | null;
+            /** @enum {string|null} */
+            afpOrdning?: "AFPKOM" | "AFPSTAT" | "FINANS" | "KONV_K" | "KONV_O" | "LONHO" | "NAVO" | null;
+            innvilgetLivsvarigOffentligAfp?: components["schemas"]["PersonligSimuleringInnvilgetLivsvarigOffentligAfpSpecV9"][] | null;
         };
-        PersonligSimuleringUtenlandsperiodeSpecV8: {
+        PersonligSimuleringUtenlandsperiodeSpecV9: {
             /** Format: date */
             fom: string;
             /** Format: date */
-            tom?: string;
+            tom?: string | null;
             landkode: string;
             arbeidetUtenlands: boolean;
         };
-        PersonligSimuleringAarligInntektResultV8: {
+        PersonligSimuleringAarligInntektResultV9: {
             /** Format: int32 */
             aar: number;
             /** Format: int32 */
             pensjonsgivendeInntektBeloep: number;
         };
-        PersonligSimuleringAarligPensjonResultV8: {
+        PersonligSimuleringAarligPensjonResultV9: {
             /** Format: int32 */
             alder: number;
             /** Format: int32 */
             beloep: number;
             /** Format: int32 */
-            maanedligBeloep?: number;
+            maanedligBeloep?: number | null;
         };
-        PersonligSimuleringAlderResultV8: {
+        PersonligSimuleringAfpPrivatResultV9: {
+            /** Format: int32 */
+            alder: number;
+            /** Format: int32 */
+            beloep: number;
+            /** Format: int32 */
+            kompensasjonstillegg: number;
+            /** Format: int32 */
+            kronetillegg: number;
+            /** Format: int32 */
+            livsvarig: number;
+            /** Format: int32 */
+            maanedligBeloep?: number | null;
+        };
+        PersonligSimuleringAlderResultV9: {
             /** Format: int32 */
             aar: number;
             /** Format: int32 */
             maaneder: number;
         };
-        PersonligSimuleringAlderspensjonResultV8: {
+        PersonligSimuleringAlderspensjonResultV9: {
             /** Format: int32 */
             alder: number;
             /** Format: int32 */
             beloep: number;
             /** Format: int32 */
-            inntektspensjonBeloep?: number;
+            inntektspensjonBeloep?: number | null;
             /** Format: int32 */
-            garantipensjonBeloep?: number;
+            garantipensjonBeloep?: number | null;
             /** Format: double */
-            delingstall?: number;
+            delingstall?: number | null;
             /** Format: int32 */
-            pensjonBeholdningFoerUttakBeloep?: number;
+            pensjonBeholdningFoerUttakBeloep?: number | null;
             /** Format: double */
-            andelsbroekKap19?: number;
+            andelsbroekKap19?: number | null;
             /** Format: double */
-            andelsbroekKap20?: number;
+            andelsbroekKap20?: number | null;
             /** Format: double */
-            sluttpoengtall?: number;
+            sluttpoengtall?: number | null;
             /** Format: int32 */
-            trygdetidKap19?: number;
+            trygdetidKap19?: number | null;
             /** Format: int32 */
-            trygdetidKap20?: number;
+            trygdetidKap20?: number | null;
             /** Format: int32 */
-            poengaarFoer92?: number;
+            poengaarFoer92?: number | null;
             /** Format: int32 */
-            poengaarEtter91?: number;
+            poengaarEtter91?: number | null;
             /** Format: double */
-            forholdstall?: number;
+            forholdstall?: number | null;
             /** Format: int32 */
-            grunnpensjon?: number;
+            grunnpensjon?: number | null;
             /** Format: int32 */
-            tilleggspensjon?: number;
+            tilleggspensjon?: number | null;
             /** Format: int32 */
-            pensjonstillegg?: number;
+            pensjonstillegg?: number | null;
             /** Format: int32 */
-            skjermingstillegg?: number;
+            skjermingstillegg?: number | null;
+            /** Format: int32 */
+            kapittel19Gjenlevendetillegg?: number | null;
         };
-        PersonligSimuleringAlternativResultV8: {
-            gradertUttaksalder?: components["schemas"]["PersonligSimuleringAlderResultV8"];
+        PersonligSimuleringAlternativResultV9: {
+            gradertUttaksalder?: components["schemas"]["PersonligSimuleringAlderResultV9"] | null;
             /** Format: int32 */
-            uttaksgrad?: number;
-            heltUttaksalder: components["schemas"]["PersonligSimuleringAlderResultV8"];
+            uttaksgrad?: number | null;
+            heltUttaksalder: components["schemas"]["PersonligSimuleringAlderResultV9"];
         };
-        PersonligSimuleringMaanedligPensjonResultV8: {
+        PersonligSimuleringMaanedligPensjonResultV9: {
             /** Format: int32 */
-            gradertUttakMaanedligBeloep?: number;
+            gradertUttakMaanedligBeloep?: number | null;
             /** Format: int32 */
             heltUttakMaanedligBeloep: number;
         };
-        PersonligSimuleringPre2025OffentligAfpResultV8: {
+        PersonligSimuleringPre2025OffentligAfpResultV9: {
             /** Format: int32 */
             alderAar: number;
             /** Format: int32 */
@@ -695,21 +860,67 @@ export interface components {
             afpGrad: number;
             afpAvkortetTil70Prosent: boolean;
         };
-        PersonligSimuleringResultV8: {
-            alderspensjon: components["schemas"]["PersonligSimuleringAlderspensjonResultV8"][];
-            alderspensjonMaanedligVedEndring?: components["schemas"]["PersonligSimuleringMaanedligPensjonResultV8"];
-            pre2025OffentligAfp?: components["schemas"]["PersonligSimuleringPre2025OffentligAfpResultV8"];
-            afpPrivat?: components["schemas"]["PersonligSimuleringAarligPensjonResultV8"][];
-            afpOffentlig?: components["schemas"]["PersonligSimuleringAarligPensjonResultV8"][];
-            vilkaarsproeving: components["schemas"]["PersonligSimuleringVilkaarsproevingResultV8"];
-            harForLiteTrygdetid?: boolean;
+        PersonligSimuleringResultV9: {
+            alderspensjon: components["schemas"]["PersonligSimuleringAlderspensjonResultV9"][];
+            alderspensjonMaanedligVedEndring?: components["schemas"]["PersonligSimuleringMaanedligPensjonResultV9"] | null;
+            pre2025OffentligAfp?: components["schemas"]["PersonligSimuleringPre2025OffentligAfpResultV9"] | null;
+            afpPrivat?: components["schemas"]["PersonligSimuleringAfpPrivatResultV9"][] | null;
+            afpOffentlig?: components["schemas"]["PersonligSimuleringAarligPensjonResultV9"][] | null;
+            vilkaarsproeving: components["schemas"]["PersonligSimuleringVilkaarsproevingResultV9"];
+            harForLiteTrygdetid?: boolean | null;
             /** Format: int32 */
-            trygdetid?: number;
-            opptjeningGrunnlagListe?: components["schemas"]["PersonligSimuleringAarligInntektResultV8"][];
+            trygdetid?: number | null;
+            opptjeningGrunnlagListe?: components["schemas"]["PersonligSimuleringAarligInntektResultV9"][] | null;
         };
-        PersonligSimuleringVilkaarsproevingResultV8: {
+        PersonligSimuleringVilkaarsproevingResultV9: {
             vilkaarErOppfylt: boolean;
-            alternativ?: components["schemas"]["PersonligSimuleringAlternativResultV8"];
+            alternativ?: components["schemas"]["PersonligSimuleringAlternativResultV9"] | null;
+        };
+        PersonligSimuleringInnvilgetLivsvarigOffentligAfpSpecV3: {
+            /** Format: double */
+            aarligBruttoBeloep?: number;
+            /** Format: date */
+            uttakFom?: string;
+            /** Format: int32 */
+            sistRegulertGrunnbeloep?: number | null;
+        };
+        UttaksalderAlderSpecV3: {
+            /** Format: int32 */
+            aar: number;
+            /** Format: int32 */
+            maaneder: number;
+        };
+        UttaksalderInntektSpecV3: {
+            /** Format: int32 */
+            beloep: number;
+            sluttAlder?: components["schemas"]["UttaksalderAlderSpecV3"] | null;
+        };
+        UttaksalderSpecV3: {
+            /** @enum {string|null} */
+            simuleringstype?: "ALDERSPENSJON" | "PRE2025_OFFENTLIG_AFP_ETTERFULGT_AV_ALDERSPENSJON" | "ALDERSPENSJON_MED_AFP_PRIVAT" | "ALDERSPENSJON_MED_AFP_OFFENTLIG_LIVSVARIG" | "ALDERSPENSJON_MED_GJENLEVENDERETT" | "ENDRING_ALDERSPENSJON" | "ENDRING_ALDERSPENSJON_MED_AFP_PRIVAT" | "ENDRING_ALDERSPENSJON_MED_AFP_OFFENTLIG_LIVSVARIG" | "ENDRING_ALDERSPENSJON_MED_GJENLEVENDERETT" | "SERVICEBEREGN_AFP" | null;
+            /** Format: int32 */
+            aarligInntektFoerUttakBeloep?: number | null;
+            aarligInntektVsaPensjon?: components["schemas"]["UttaksalderInntektSpecV3"] | null;
+            utenlandsperiodeListe?: components["schemas"]["UttaksalderUtenlandsperiodeSpecV3"][] | null;
+            /** @enum {string|null} */
+            sivilstand?: "UNKNOWN" | "UOPPGITT" | "UGIFT" | "GIFT" | "ENKE_ELLER_ENKEMANN" | "SKILT" | "SEPARERT" | "REGISTRERT_PARTNER" | "SEPARERT_PARTNER" | "SKILT_PARTNER" | "GJENLEVENDE_PARTNER" | "SAMBOER" | null;
+            epsHarInntektOver2G: boolean;
+            epsHarPensjon: boolean;
+            innvilgetLivsvarigOffentligAfp?: components["schemas"]["PersonligSimuleringInnvilgetLivsvarigOffentligAfpSpecV3"][] | null;
+        };
+        UttaksalderUtenlandsperiodeSpecV3: {
+            /** Format: date */
+            fom?: string;
+            /** Format: date */
+            tom?: string | null;
+            landkode?: string;
+            arbeidetUtenlands?: boolean;
+        };
+        UttaksalderResultV3: {
+            /** Format: int32 */
+            aar: number;
+            /** Format: int32 */
+            maaneder: number;
         };
         PensjonsavtaleAlderSpecV3: {
             /** Format: int32 */
@@ -720,15 +931,15 @@ export interface components {
         PensjonsavtaleInntektSpecV3: {
             /** Format: int32 */
             beloep: number;
-            sluttAlder?: components["schemas"]["PensjonsavtaleAlderSpecV3"];
+            sluttAlder?: components["schemas"]["PensjonsavtaleAlderSpecV3"] | null;
         };
         PensjonsavtaleSpecV3: {
             /** Format: int32 */
             aarligInntektFoerUttakBeloep: number;
             uttaksperioder: components["schemas"]["PensjonsavtaleUttaksperiodeSpecV3"][];
-            harAfp?: boolean;
-            /** @enum {string} */
-            sivilstand?: "UNKNOWN" | "UOPPGITT" | "UGIFT" | "GIFT" | "ENKE_ELLER_ENKEMANN" | "SKILT" | "SEPARERT" | "REGISTRERT_PARTNER" | "SEPARERT_PARTNER" | "SKILT_PARTNER" | "GJENLEVENDE_PARTNER" | "SAMBOER";
+            harAfp?: boolean | null;
+            /** @enum {string|null} */
+            sivilstand?: "UNKNOWN" | "UOPPGITT" | "UGIFT" | "GIFT" | "ENKE_ELLER_ENKEMANN" | "SKILT" | "SEPARERT" | "REGISTRERT_PARTNER" | "SEPARERT_PARTNER" | "SKILT_PARTNER" | "GJENLEVENDE_PARTNER" | "SAMBOER" | null;
             epsHarInntektOver2G: boolean;
             epsHarPensjon: boolean;
         };
@@ -736,7 +947,7 @@ export interface components {
             startAlder: components["schemas"]["PensjonsavtaleAlderSpecV3"];
             /** Format: int32 */
             grad: number;
-            aarligInntektVsaPensjon?: components["schemas"]["PensjonsavtaleInntektSpecV3"];
+            aarligInntektVsaPensjon?: components["schemas"]["PensjonsavtaleInntektSpecV3"] | null;
         };
         Alder: {
             /** Format: int32 */
@@ -755,7 +966,7 @@ export interface components {
             /** Format: int32 */
             startAar: number;
             /** Format: int32 */
-            sluttAar?: number;
+            sluttAar?: number | null;
             utbetalingsperioder: components["schemas"]["UtbetalingsperiodeV3"][];
         };
         SelskapV3: {
@@ -764,65 +975,11 @@ export interface components {
         };
         UtbetalingsperiodeV3: {
             startAlder: components["schemas"]["Alder"];
-            sluttAlder?: components["schemas"]["Alder"];
+            sluttAlder?: components["schemas"]["Alder"] | null;
             /** Format: int32 */
             aarligUtbetaling: number;
             /** Format: int32 */
             grad: number;
-        };
-        UttaksalderAlderSpecV2: {
-            /** Format: int32 */
-            aar: number;
-            /** Format: int32 */
-            maaneder: number;
-        };
-        UttaksalderInntektSpecV2: {
-            /** Format: int32 */
-            beloep: number;
-            sluttAlder?: components["schemas"]["UttaksalderAlderSpecV2"];
-        };
-        UttaksalderSpecV2: {
-            /** @enum {string} */
-            simuleringstype?: "ALDERSPENSJON" | "PRE2025_OFFENTLIG_AFP_ETTERFULGT_AV_ALDERSPENSJON" | "ALDERSPENSJON_MED_AFP_PRIVAT" | "ALDERSPENSJON_MED_AFP_OFFENTLIG_LIVSVARIG" | "ENDRING_ALDERSPENSJON" | "ENDRING_ALDERSPENSJON_MED_AFP_PRIVAT" | "ENDRING_ALDERSPENSJON_MED_AFP_OFFENTLIG_LIVSVARIG";
-            /** Format: int32 */
-            aarligInntektFoerUttakBeloep?: number;
-            aarligInntektVsaPensjon?: components["schemas"]["UttaksalderInntektSpecV2"];
-            utenlandsperiodeListe?: components["schemas"]["UttaksalderUtenlandsperiodeSpecV2"][];
-            /** @enum {string} */
-            sivilstand?: "UNKNOWN" | "UOPPGITT" | "UGIFT" | "GIFT" | "ENKE_ELLER_ENKEMANN" | "SKILT" | "SEPARERT" | "REGISTRERT_PARTNER" | "SEPARERT_PARTNER" | "SKILT_PARTNER" | "GJENLEVENDE_PARTNER" | "SAMBOER";
-            epsHarInntektOver2G: boolean;
-            epsHarPensjon: boolean;
-        };
-        UttaksalderUtenlandsperiodeSpecV2: {
-            /** Format: date */
-            fom: string;
-            /** Format: date */
-            tom?: string;
-            landkode: string;
-            arbeidetUtenlands: boolean;
-        };
-        UttaksalderError: {
-            /** @enum {string} */
-            errorCode: "AFP_IKKE_I_VILKAARSPROEVING";
-            cause?: string;
-        };
-        UttaksalderResultV2: {
-            /** Format: int32 */
-            aar: number;
-            /** Format: int32 */
-            maaneder: number;
-        };
-        IngressSimuleringOffentligTjenestepensjonSpecV2: {
-            /** Format: date */
-            foedselsdato: string;
-            /** Format: int32 */
-            aarligInntektFoerUttakBeloep: number;
-            gradertUttak?: components["schemas"]["SimuleringOffentligTjenestepensjonGradertUttakV2"];
-            heltUttak: components["schemas"]["SimuleringOffentligTjenestepensjonHeltUttakV2"];
-            utenlandsperiodeListe: components["schemas"]["UtenlandsoppholdV2"][];
-            epsHarPensjon: boolean;
-            epsHarInntektOver2G: boolean;
-            brukerBaOmAfp: boolean;
         };
         SimuleringOffentligTjenestepensjonAlderV2: {
             /** Format: int32 */
@@ -833,29 +990,42 @@ export interface components {
         SimuleringOffentligTjenestepensjonGradertUttakV2: {
             uttaksalder: components["schemas"]["SimuleringOffentligTjenestepensjonAlderV2"];
             /** Format: int32 */
-            aarligInntektVsaPensjonBeloep?: number;
+            aarligInntektVsaPensjonBeloep?: number | null;
         };
         SimuleringOffentligTjenestepensjonHeltUttakV2: {
             uttaksalder: components["schemas"]["SimuleringOffentligTjenestepensjonAlderV2"];
-            aarligInntektVsaPensjon?: components["schemas"]["SimuleringOffentligTjenestepensjonInntektV2"];
+            aarligInntektVsaPensjon?: components["schemas"]["SimuleringOffentligTjenestepensjonInntektV2"] | null;
         };
         SimuleringOffentligTjenestepensjonInntektV2: {
             /** Format: int32 */
             beloep: number;
             sluttAlder: components["schemas"]["SimuleringOffentligTjenestepensjonAlderV2"];
         };
+        SimuleringOffentligTjenestepensjonSpecV2: {
+            /** Format: date */
+            foedselsdato: string;
+            /** Format: int32 */
+            aarligInntektFoerUttakBeloep: number;
+            gradertUttak?: components["schemas"]["SimuleringOffentligTjenestepensjonGradertUttakV2"] | null;
+            heltUttak: components["schemas"]["SimuleringOffentligTjenestepensjonHeltUttakV2"];
+            utenlandsperiodeListe: components["schemas"]["UtenlandsoppholdV2"][];
+            epsHarPensjon: boolean;
+            epsHarInntektOver2G: boolean;
+            brukerBaOmAfp: boolean;
+            erApoteker?: boolean | null;
+        };
         UtenlandsoppholdV2: {
             /** Format: date */
             fom: string;
             /** Format: date */
-            tom?: string;
+            tom?: string | null;
         };
-        OffentligTjenestepensjonSimuleringsresultatDtoV2: {
+        OffentligTjenestepensjonSimuleringResultV2: {
             /** @enum {string} */
             simuleringsresultatStatus: "OK" | "BRUKER_ER_IKKE_MEDLEM_AV_TP_ORDNING" | "TP_ORDNING_STOETTES_IKKE" | "TOM_SIMULERING_FRA_TP_ORDNING" | "TEKNISK_FEIL";
             muligeTpLeverandoerListe: string[];
-            simulertTjenestepensjon?: components["schemas"]["SimulertTjenestepensjonV2"];
-            serviceData?: string[];
+            simulertTjenestepensjon?: components["schemas"]["SimulertTjenestepensjonV2"] | null;
+            serviceData?: string[] | null;
         };
         SimuleringsresultatV2: {
             utbetalingsperioder: components["schemas"]["UtbetalingsperiodeV2"][];
@@ -868,138 +1038,61 @@ export interface components {
         };
         UtbetalingsperiodeV2: {
             startAlder: components["schemas"]["Alder"];
-            sluttAlder?: components["schemas"]["Alder"];
+            sluttAlder?: components["schemas"]["Alder"] | null;
             /** Format: int32 */
             aarligUtbetaling: number;
             /** Format: int32 */
-            maanedligUtbetaling?: number;
+            maanedligUtbetaling?: number | null;
         };
-        PensjonsavtaleAlderSpecV2: {
-            /** Format: int32 */
-            aar: number;
-            /** Format: int32 */
-            maaneder: number;
-        };
-        PensjonsavtaleInntektSpecV2: {
-            /** Format: int32 */
-            beloep: number;
-            sluttAlder?: components["schemas"]["PensjonsavtaleAlderSpecV2"];
-        };
-        PensjonsavtaleOppholdSpecV2: {
-            /** Format: date */
-            fom: string;
-            /** Format: date */
-            tom?: string;
-        };
-        PensjonsavtaleSpecV2: {
-            /** Format: int32 */
-            aarligInntektFoerUttakBeloep: number;
-            uttaksperioder: components["schemas"]["PensjonsavtaleUttaksperiodeSpecV2"][];
-            harAfp?: boolean;
-            harEpsPensjon?: boolean;
-            harEpsPensjonsgivendeInntektOver2G?: boolean;
-            /** Format: int32 */
-            antallAarIUtlandetEtter16?: number;
-            utenlandsperioder?: components["schemas"]["PensjonsavtaleOppholdSpecV2"][];
+        SimuleringOffentligTjenestepensjonFoer1963SpecV1: {
             /** @enum {string} */
-            sivilstand?: "UNKNOWN" | "UOPPGITT" | "UGIFT" | "GIFT" | "ENKE_ELLER_ENKEMANN" | "SKILT" | "SEPARERT" | "REGISTRERT_PARTNER" | "SEPARERT_PARTNER" | "SKILT_PARTNER" | "GJENLEVENDE_PARTNER" | "SAMBOER";
-        };
-        PensjonsavtaleUttaksperiodeSpecV2: {
-            startAlder: components["schemas"]["PensjonsavtaleAlderSpecV2"];
-            /** Format: int32 */
-            grad: number;
-            aarligInntektVsaPensjon?: components["schemas"]["PensjonsavtaleInntektSpecV2"];
-        };
-        PensjonsavtaleResultV2: {
-            avtaler: components["schemas"]["PensjonsavtaleV2"][];
-            utilgjengeligeSelskap: components["schemas"]["SelskapV2"][];
-        };
-        PensjonsavtaleV2: {
-            produktbetegnelse: string;
-            /** @enum {string} */
-            kategori: "UNKNOWN" | "INDIVIDUELL_ORDNING" | "PRIVAT_TJENESTEPENSJON";
-            /** Format: int32 */
-            startAar: number;
-            /** Format: int32 */
-            sluttAar?: number;
-            utbetalingsperioder: components["schemas"]["UtbetalingsperiodeV2"][];
-        };
-        SelskapV2: {
-            navn: string;
-            heltUtilgjengelig: boolean;
-        };
-        IngressUttaksalderAlderV1: {
-            /** Format: int32 */
-            aar: number;
-            /** Format: int32 */
-            maaneder: number;
-        };
-        IngressUttaksalderInntektV1: {
-            /** Format: int32 */
-            beloep: number;
-            sluttAlder?: components["schemas"]["IngressUttaksalderAlderV1"];
-        };
-        IngressUttaksalderSpecForHeltUttakV1: {
-            /** @enum {string} */
-            simuleringstype?: "ALDERSPENSJON" | "PRE2025_OFFENTLIG_AFP_ETTERFULGT_AV_ALDERSPENSJON" | "ALDERSPENSJON_MED_AFP_PRIVAT" | "ALDERSPENSJON_MED_AFP_OFFENTLIG_LIVSVARIG" | "ENDRING_ALDERSPENSJON" | "ENDRING_ALDERSPENSJON_MED_AFP_PRIVAT" | "ENDRING_ALDERSPENSJON_MED_AFP_OFFENTLIG_LIVSVARIG";
-            /** @enum {string} */
-            sivilstand?: "UNKNOWN" | "UOPPGITT" | "UGIFT" | "GIFT" | "ENKE_ELLER_ENKEMANN" | "SKILT" | "SEPARERT" | "REGISTRERT_PARTNER" | "SEPARERT_PARTNER" | "SKILT_PARTNER" | "GJENLEVENDE_PARTNER" | "SAMBOER";
-            harEps?: boolean;
-            /** Format: int32 */
-            aarligInntektFoerUttakBeloep?: number;
-            aarligInntektVsaPensjon?: components["schemas"]["IngressUttaksalderInntektV1"];
-            utenlandsperiodeListe?: components["schemas"]["UttaksalderUtenlandsperiodeSpecV1"][];
-        };
-        UttaksalderUtenlandsperiodeSpecV1: {
-            /** Format: date */
-            fom: string;
-            /** Format: date */
-            tom?: string;
-            landkode: string;
-            arbeidetUtenlands: boolean;
-        };
-        AlderDto: {
-            /** Format: int32 */
-            aar: number;
-            /** Format: int32 */
-            maaneder: number;
-        };
-        IngressSimuleringOffentligTjenestepensjonSpecV1: {
+            simuleringstype: "ALDERSPENSJON" | "PRE2025_OFFENTLIG_AFP_ETTERFULGT_AV_ALDERSPENSJON" | "ALDERSPENSJON_MED_AFP_PRIVAT" | "ALDERSPENSJON_MED_AFP_OFFENTLIG_LIVSVARIG" | "ALDERSPENSJON_MED_GJENLEVENDERETT" | "ENDRING_ALDERSPENSJON" | "ENDRING_ALDERSPENSJON_MED_AFP_PRIVAT" | "ENDRING_ALDERSPENSJON_MED_AFP_OFFENTLIG_LIVSVARIG" | "ENDRING_ALDERSPENSJON_MED_GJENLEVENDERETT" | "SERVICEBEREGN_AFP";
             /** Format: date */
             foedselsdato: string;
-            uttaksalder: components["schemas"]["Alder"];
             /** Format: int32 */
-            aarligInntektFoerUttakBeloep: number;
-            utenlandsperiodeListe: components["schemas"]["UtenlandsoppholdV1"][];
-            epsHarPensjon: boolean;
-            epsHarInntektOver2G: boolean;
-            brukerBaOmAfp: boolean;
+            aarligInntektFoerUttakBeloep?: number | null;
+            gradertUttak?: components["schemas"]["PersonligSimuleringGradertUttakSpecV9"] | null;
+            heltUttak: components["schemas"]["PersonligSimuleringHeltUttakSpecV9"];
+            utenlandsperiodeListe?: components["schemas"]["PersonligSimuleringUtenlandsperiodeSpecV9"][] | null;
+            /** @enum {string|null} */
+            sivilstand?: "UNKNOWN" | "UOPPGITT" | "UGIFT" | "GIFT" | "ENKE_ELLER_ENKEMANN" | "SKILT" | "SEPARERT" | "REGISTRERT_PARTNER" | "SEPARERT_PARTNER" | "SKILT_PARTNER" | "GJENLEVENDE_PARTNER" | "SAMBOER" | null;
+            epsHarInntektOver2G?: boolean | null;
+            epsHarPensjon?: boolean | null;
+            afpInntektMaanedFoerUttak?: boolean | null;
+            /** @enum {string|null} */
+            afpOrdning?: "AFPKOM" | "AFPSTAT" | "FINANS" | "KONV_K" | "KONV_O" | "LONHO" | "NAVO" | null;
+            stillingsprosentOffHeltUttak: string;
+            stillingsprosentOffGradertUttak?: string | null;
         };
-        UtenlandsoppholdV1: {
-            /** Format: date */
-            fom: string;
-            /** Format: date */
-            tom?: string;
-        };
-        OffentligTjenestepensjonSimuleringsresultatDtoV1: {
+        OffentligTjenestepensjonSimuleringFoer1963ResultV1: {
             /** @enum {string} */
             simuleringsresultatStatus: "OK" | "BRUKER_ER_IKKE_MEDLEM_AV_TP_ORDNING" | "TP_ORDNING_STOETTES_IKKE" | "TOM_SIMULERING_FRA_TP_ORDNING" | "TEKNISK_FEIL";
             muligeTpLeverandoerListe: string[];
-            simulertTjenestepensjon?: components["schemas"]["SimulertTjenestepensjonV1"];
+            simulertTjenestepensjon?: components["schemas"]["SimulertTjenestepensjonFoer1963V1"] | null;
+            serviceData?: string[] | null;
+            /** @enum {string|null} */
+            feilkode?: "TEKNISK_FEIL" | "BEREGNING_GIR_NULL_UTBETALING" | "BRUKER_IKKE_MEDLEM_AV_TP_ORDNING" | "TP_ORDNING_STOETTES_IKKE" | "OPPFYLLER_IKKE_INNGANGSVILKAAR" | null;
         };
-        SimuleringsresultatV1: {
-            utbetalingsperioder: components["schemas"]["UtbetalingsperiodeV1"][];
-            betingetTjenestepensjonErInkludert: boolean;
+        SimuleringsresultatFoer1963V1: {
+            utbetalingsperioder: components["schemas"]["UtbetalingsperiodeFoer1963V1"][];
         };
-        SimulertTjenestepensjonV1: {
+        SimulertTjenestepensjonFoer1963V1: {
             tpLeverandoer: string;
-            simuleringsresultat: components["schemas"]["SimuleringsresultatV1"];
+            tpNummer: string;
+            simuleringsresultat: components["schemas"]["SimuleringsresultatFoer1963V1"];
         };
-        UtbetalingsperiodeV1: {
+        UtbetalingsperiodeFoer1963V1: {
             startAlder: components["schemas"]["Alder"];
-            sluttAlder?: components["schemas"]["Alder"];
+            sluttAlder?: components["schemas"]["Alder"] | null;
             /** Format: int32 */
             aarligUtbetaling: number;
+            /** Format: int32 */
+            grad?: number | null;
+            /** @enum {string} */
+            ytelsekode: "AP" | "AFP" | "SERALDER";
+            mangelfullSimuleringkode?: string | null;
+            /** Format: int32 */
+            maanedligUtbetaling?: number | null;
         };
         AnonymSimuleringAlderV1: {
             /** Format: int32 */
@@ -1012,33 +1105,33 @@ export interface components {
             grad: number;
             uttaksalder: components["schemas"]["AnonymSimuleringAlderV1"];
             /** Format: int32 */
-            aarligInntektVsaPensjonBeloep?: number;
+            aarligInntektVsaPensjonBeloep?: number | null;
         };
         AnonymSimuleringHeltUttakV1: {
             uttaksalder: components["schemas"]["AnonymSimuleringAlderV1"];
-            aarligInntektVsaPensjon?: components["schemas"]["AnonymSimuleringInntektV1"];
+            aarligInntektVsaPensjon?: components["schemas"]["AnonymSimuleringInntektV1"] | null;
         };
         AnonymSimuleringInntektV1: {
             /** Format: int32 */
             beloep: number;
-            sluttAlder?: components["schemas"]["AnonymSimuleringAlderV1"];
+            sluttAlder?: components["schemas"]["AnonymSimuleringAlderV1"] | null;
         };
         AnonymSimuleringSpecV1: {
-            /** @enum {string} */
-            simuleringstype?: "ALDERSPENSJON" | "ALDERSPENSJON_MED_AFP_PRIVAT";
+            /** @enum {string|null} */
+            simuleringstype?: "ALDERSPENSJON" | "ALDERSPENSJON_MED_AFP_PRIVAT" | null;
             /** Format: int32 */
             foedselAar: number;
-            /** @enum {string} */
-            sivilstand?: "UGIFT" | "GIFT" | "SAMBOER";
-            epsHarInntektOver2G?: boolean;
-            epsHarPensjon?: boolean;
+            /** @enum {string|null} */
+            sivilstand?: "UGIFT" | "GIFT" | "SAMBOER" | null;
+            epsHarInntektOver2G?: boolean | null;
+            epsHarPensjon?: boolean | null;
             /** Format: int32 */
-            utenlandsAntallAar?: number;
+            utenlandsAntallAar?: number | null;
             /** Format: int32 */
-            inntektOver1GAntallAar?: number;
+            inntektOver1GAntallAar?: number | null;
             /** Format: int32 */
-            aarligInntektFoerUttakBeloep?: number;
-            gradertUttak?: components["schemas"]["AnonymSimuleringGradertUttakV1"];
+            aarligInntektFoerUttakBeloep?: number | null;
+            gradertUttak?: components["schemas"]["AnonymSimuleringGradertUttakV1"] | null;
             heltUttak: components["schemas"]["AnonymSimuleringHeltUttakV1"];
         };
         AnonymSimuleringErrorV1: {
@@ -1052,9 +1145,9 @@ export interface components {
             maaneder: number;
         };
         AnonymAlternativV1: {
-            gradertUttaksalder?: components["schemas"]["AnonymAlderV1"];
+            gradertUttaksalder?: components["schemas"]["AnonymAlderV1"] | null;
             /** Format: int32 */
-            uttaksgrad?: number;
+            uttaksgrad?: number | null;
             heltUttaksalder: components["schemas"]["AnonymAlderV1"];
         };
         AnonymPensjonsberegningAfpOffentligV1: {
@@ -1071,34 +1164,753 @@ export interface components {
         };
         AnonymSimuleringResultV1: {
             alderspensjon: components["schemas"]["AnonymPensjonsberegningV1"][];
-            afpPrivat?: components["schemas"]["AnonymPensjonsberegningV1"][];
-            afpOffentlig?: components["schemas"]["AnonymPensjonsberegningAfpOffentligV1"][];
+            afpPrivat?: components["schemas"]["AnonymPensjonsberegningV1"][] | null;
+            afpOffentlig?: components["schemas"]["AnonymPensjonsberegningAfpOffentligV1"][] | null;
             vilkaarsproeving: components["schemas"]["AnonymVilkaarsproevingV1"];
         };
         AnonymVilkaarsproevingV1: {
             vilkaarErOppfylt: boolean;
-            alternativ?: components["schemas"]["AnonymAlternativV1"];
+            alternativ?: components["schemas"]["AnonymAlternativV1"] | null;
         };
-        AldersgrenseSpec: {
-            /** Format: int32 */
-            foedselsdato: number;
-        };
-        AldersgrenseResultV1: {
-            normertPensjoneringsalder: components["schemas"]["PersonAlder"];
-            nedreAldersgrense: components["schemas"]["PersonAlder"];
-        };
-        PersonAlder: {
+        SimuleringV1AlderSpec: {
             /** Format: int32 */
             aar: number;
             /** Format: int32 */
             maaneder: number;
+        };
+        SimuleringV1AvdoedEps: {
+            pid: string;
+            /** Format: date */
+            doedsdato: string;
+            medlemAvFolketrygden?: boolean | null;
+            /** Format: int32 */
+            inntektFoerDoedBeloep?: number | null;
+            inntektErOverGrunnbeloepet?: boolean | null;
+            /** Format: int32 */
+            antallAarUtenlands?: number | null;
+        };
+        SimuleringV1EpsSpec: {
+            levende?: components["schemas"]["SimuleringV1LevendeEps"] | null;
+            avdoed?: components["schemas"]["SimuleringV1AvdoedEps"] | null;
+        };
+        SimuleringV1GradertUttakSpec: {
+            /** Format: int32 */
+            grad: number;
+            uttaksalder: components["schemas"]["SimuleringV1AlderSpec"];
+            /** Format: int32 */
+            aarligInntektVsaPensjonBeloep?: number | null;
+        };
+        SimuleringV1HeltUttakSpec: {
+            uttaksalder: components["schemas"]["SimuleringV1AlderSpec"];
+            aarligInntektVsaPensjon?: components["schemas"]["SimuleringV1InntektSpec"] | null;
+        };
+        SimuleringV1InntektSpec: {
+            /** Format: int32 */
+            beloep: number;
+            sluttAlder: components["schemas"]["SimuleringV1AlderSpec"];
+        };
+        SimuleringV1InnvilgetLivsvarigOffentligAfpSpec: {
+            /** Format: double */
+            aarligBruttoBeloep: number;
+            /** Format: date */
+            uttakFom: string;
+            /** Format: int32 */
+            sistRegulertGrunnbeloep?: number | null;
+        };
+        SimuleringV1LevendeEps: {
+            harInntektOver2G: boolean;
+            harPensjon: boolean;
+        };
+        SimuleringV1OffentligAfpSpec: {
+            harInntektMaanedenFoerUttak?: boolean | null;
+            /** @enum {string|null} */
+            afpOrdning?: "KOMMUNAL" | "STATLIG" | "FINANSNAERINGEN" | "KONVERTERT_PRIVAT" | "KONVERTERT_OFFENTLIG" | "LO_NHO_ORDNINGEN" | "SPEKTER" | null;
+            innvilgetLivsvarigAfpListe?: components["schemas"]["SimuleringV1InnvilgetLivsvarigOffentligAfpSpec"][] | null;
+            /** Format: int32 */
+            inntektForrigeKalenderaar?: number | null;
+            /** Format: int32 */
+            inntektFremTilUttak?: number | null;
+            /** Format: int32 */
+            inntektMaanedFoerAfp?: number | null;
+        };
+        SimuleringV1Spec: {
+            /** @enum {string} */
+            simuleringstype: "ALDERSPENSJON" | "ALDERSPENSJON_MED_TIDSBEGRENSET_OFFENTLIG_AFP" | "ALDERSPENSJON_MED_LIVSVARIG_OFFENTLIG_AFP" | "ALDERSPENSJON_MED_PRIVAT_AFP" | "ALDERSPENSJON_MED_GJENLEVENDERETT" | "ENDRING_ALDERSPENSJON" | "ENDRING_ALDERSPENSJON_MED_LIVSVARIG_OFFENTLIG_AFP" | "ENDRING_ALDERSPENSJON_MED_PRIVAT_AFP" | "ENDRING_ALDERSPENSJON_MED_GJENLEVENDERETT" | "SERVICEBEREGN_AFP";
+            /** Format: int32 */
+            aarligInntektFoerUttakBeloep?: number | null;
+            gradertUttak?: components["schemas"]["SimuleringV1GradertUttakSpec"] | null;
+            heltUttak: components["schemas"]["SimuleringV1HeltUttakSpec"];
+            utenlandsperiodeListe?: components["schemas"]["SimuleringV1UtenlandsperiodeSpec"][] | null;
+            /** @enum {string|null} */
+            sivilstatus?: "UNKNOWN" | "UOPPGITT" | "UGIFT" | "GIFT" | "ENKE_ELLER_ENKEMANN" | "SKILT" | "SEPARERT" | "REGISTRERT_PARTNER" | "SEPARERT_PARTNER" | "SKILT_PARTNER" | "GJENLEVENDE_PARTNER" | "SAMBOER" | null;
+            eps?: components["schemas"]["SimuleringV1EpsSpec"] | null;
+            offentligAfp?: components["schemas"]["SimuleringV1OffentligAfpSpec"] | null;
+        };
+        SimuleringV1UtenlandsperiodeSpec: {
+            /** Format: date */
+            fom: string;
+            /** Format: date */
+            tom?: string | null;
+            landkode: string;
+            arbeidetUtenlands: boolean;
+        };
+        SimuleringV1AarligBeloep: {
+            /**
+             * Format: int32
+             * @description Hvilket årstall (kalenderår) som informasjonen gjelder for
+             */
+            aarstall: number;
+            /** Format: int32 */
+            beloep: number;
+        };
+        SimuleringV1Alder: {
+            /**
+             * Format: int32
+             * @description Antall helt fylte år
+             */
+            aar: number;
+            /**
+             * Format: int32
+             * @description Antall helt fylte måneder (0..11)
+             */
+            maaneder: number;
+        };
+        SimuleringV1AldersbestemtUtbetaling: {
+            /**
+             * Format: int32
+             * @description Personens alder (år) som informasjonen gjelder for
+             */
+            alderAar: number;
+            /**
+             * Format: int32
+             * @description Årlig beløp
+             */
+            aarligBeloep: number;
+            /** Format: int32 */
+            maanedligBeloep?: number | null;
+        };
+        SimuleringV1Alderspensjon: {
+            /**
+             * Format: int32
+             * @description Personens alder (år) som informasjonen gjelder for
+             */
+            alderAar: number;
+            /**
+             * Format: int32
+             * @description Årlig pensjonsbeløp
+             */
+            beloep: number;
+            /**
+             * Format: int32
+             * @description Årlig beløp for inntektspensjon; feltet er ikke inkludert i eksternvariant når funksjonsbryter 'utvidet-simuleringsresultat' er 'av'
+             */
+            inntektspensjonBeloep?: number | null;
+            /**
+             * Format: int32
+             * @description Årlig beløp for basispensjon; feltet er ikke inkludert i eksternvariant når funksjonsbryter 'utvidet-simuleringsresultat' er 'av'
+             */
+            basispensjonBeloep?: number | null;
+            /**
+             * Format: int32
+             * @description Årlig beløp for garantipensjon; feltet er ikke inkludert i eksternvariant når funksjonsbryter 'utvidet-simuleringsresultat' er 'av'
+             */
+            garantipensjonBeloep?: number | null;
+            /**
+             * Format: double
+             * @description Sats for garantipensjon; feltet er ikke inkludert i eksternvariant når funksjonsbryter 'utvidet-simuleringsresultat' er 'av'
+             */
+            garantipensjonSats?: number | null;
+            /**
+             * Format: int32
+             * @description Årlig beløp for garantitillegg; feltet er ikke inkludert i eksternvariant når funksjonsbryter 'utvidet-simuleringsresultat' er 'av'
+             */
+            garantitilleggBeloep?: number | null;
+            /**
+             * Format: int32
+             * @description Årlig beløp for restpensjon; feltet er ikke inkludert i eksternvariant når funksjonsbryter 'utvidet-simuleringsresultat' er 'av'
+             */
+            restpensjonBeloep?: number | null;
+            /**
+             * Format: int32
+             * @description Grunnpensjon; feltet er ikke inkludert i eksternvariant når funksjonsbryter 'utvidet-simuleringsresultat' er 'av'
+             */
+            grunnpensjonBeloep?: number | null;
+            /**
+             * Format: int32
+             * @description Tilleggspensjon; feltet er ikke inkludert i eksternvariant når funksjonsbryter 'utvidet-simuleringsresultat' er 'av'
+             */
+            tilleggspensjonBeloep?: number | null;
+            /**
+             * Format: int32
+             * @description Pensjonstillegg; feltet er ikke inkludert i eksternvariant når funksjonsbryter 'utvidet-simuleringsresultat' er 'av'
+             */
+            pensjonstillegg?: number | null;
+            /**
+             * Format: int32
+             * @description Skjermingstillegg; feltet er ikke inkludert i eksternvariant når funksjonsbryter 'utvidet-simuleringsresultat' er 'av'
+             */
+            skjermingstillegg?: number | null;
+            /**
+             * Format: int32
+             * @description Årlig beløp for gjenlevendetillegg; feltet er ikke inkludert i eksternvariant når funksjonsbryter 'utvidet-simuleringsresultat' er 'av'
+             */
+            gjenlevendetillegg?: number | null;
+            /**
+             * Format: double
+             * @description Minste pensjonsnivå-sats; feltet er ikke inkludert i eksternvariant når funksjonsbryter 'utvidet-simuleringsresultat' er 'av'
+             */
+            minstePensjonsnivaaSats?: number | null;
+            /**
+             * Format: double
+             * @description Delingstall; feltet er ikke inkludert i eksternvariant når funksjonsbryter 'utvidet-simuleringsresultat' er 'av'
+             */
+            delingstall?: number | null;
+            /**
+             * Format: double
+             * @description Forholdstall; feltet er ikke inkludert i eksternvariant når funksjonsbryter 'utvidet-simuleringsresultat' er 'av'
+             */
+            forholdstall?: number | null;
+            /**
+             * Format: int32
+             * @description Beløp for pensjonsbeholdning før uttak; feltet er ikke inkludert i eksternvariant når funksjonsbryter 'utvidet-simuleringsresultat' er 'av'
+             */
+            pensjonsbeholdningFoerUttakBeloep?: number | null;
+            /**
+             * Format: double
+             * @description Andel (0..1) av pensjonen beregnet i.h.t. kapittel 19; feltet er ikke inkludert i eksternvariant når funksjonsbryter 'utvidet-simuleringsresultat' er 'av'
+             */
+            kapittel19Andel?: number | null;
+            /**
+             * Format: double
+             * @description Andel (0..1) av pensjonen beregnet i.h.t. kapittel 20; feltet er ikke inkludert i eksternvariant når funksjonsbryter 'utvidet-simuleringsresultat' er 'av'
+             */
+            kapittel20Andel?: number | null;
+            /**
+             * Format: double
+             * @description Sluttpoengtall; feltet er ikke inkludert i eksternvariant når funksjonsbryter 'utvidet-simuleringsresultat' er 'av'
+             */
+            sluttpoengtall?: number | null;
+            /**
+             * Format: int32
+             * @description Antall år trygdetid i.h.t. kapittel 19; feltet er ikke inkludert i eksternvariant når funksjonsbryter 'utvidet-simuleringsresultat' er 'av'
+             */
+            kapittel19Trygdetid?: number | null;
+            /**
+             * Format: int32
+             * @description Antall år trygdetid i.h.t. kapittel 20; feltet er ikke inkludert i eksternvariant når funksjonsbryter 'utvidet-simuleringsresultat' er 'av'
+             */
+            kapittel20Trygdetid?: number | null;
+            /**
+             * Format: int32
+             * @description Antall poengår til og med 1991; feltet er ikke inkludert i eksternvariant når funksjonsbryter 'utvidet-simuleringsresultat' er 'av'
+             */
+            poengaarTom1991?: number | null;
+            /**
+             * Format: int32
+             * @description Antall poengår fra og med 1992; feltet er ikke inkludert i eksternvariant når funksjonsbryter 'utvidet-simuleringsresultat' er 'av'
+             */
+            poengaarFom1992?: number | null;
+        };
+        SimuleringV1BeregnetAfp: {
+            /** Format: int32 */
+            totalbelopAfp?: number | null;
+            /** Format: date */
+            virkFom?: string | null;
+            /** Format: int32 */
+            tidligereArbeidsinntekt?: number | null;
+            /** Format: int32 */
+            grunnbelop?: number | null;
+            /** Format: double */
+            sluttpoengtall?: number | null;
+            /** Format: int32 */
+            trygdetid?: number | null;
+            /** Format: int32 */
+            poengar?: number | null;
+            /** Format: int32 */
+            poeangarF92?: number | null;
+            /** Format: int32 */
+            poeangarE91?: number | null;
+            /** Format: int32 */
+            grunnpensjon?: number | null;
+            /** Format: int32 */
+            tilleggspensjon?: number | null;
+            /** Format: int32 */
+            afpTillegg?: number | null;
+            /** Format: double */
+            fpp?: number | null;
+            /** Format: int32 */
+            saertillegg?: number | null;
+            /** Format: int32 */
+            afpGrad?: number | null;
+            erAvkortet?: boolean | null;
+        };
+        SimuleringV1MaanedligAlderspensjon: {
+            /** Format: int32 */
+            beloep: number;
+            /** Format: int32 */
+            inntektspensjonBeloep?: number | null;
+            /** Format: double */
+            delingstall?: number | null;
+            /** Format: int32 */
+            pensjonsbeholdningFoerUttakBeloep?: number | null;
+            /** Format: int32 */
+            pensjonsbeholdningEtterUttakBeloep?: number | null;
+            /** Format: double */
+            sluttpoengtall?: number | null;
+            /** Format: int32 */
+            poengaarTom1991?: number | null;
+            /** Format: int32 */
+            poengaarFom1992?: number | null;
+            /** Format: double */
+            forholdstall?: number | null;
+            /** Format: int32 */
+            grunnpensjonBeloep?: number | null;
+            /** Format: int32 */
+            tilleggspensjonBeloep?: number | null;
+            /** Format: int32 */
+            pensjonstillegg?: number | null;
+            /** Format: int32 */
+            skjermingstillegg?: number | null;
+            /** Format: double */
+            kapittel19Andel?: number | null;
+            /** Format: int32 */
+            kapittel19Trygdetid?: number | null;
+            /** Format: int32 */
+            basispensjonBeloep?: number | null;
+            /** Format: int32 */
+            restpensjonBeloep?: number | null;
+            /** Format: int32 */
+            gjenlevendetillegg?: number | null;
+            /** Format: double */
+            minstePensjonsnivaaSats?: number | null;
+            /** Format: double */
+            kapittel20Andel?: number | null;
+            /** Format: int32 */
+            kapittel20Trygdetid?: number | null;
+            /** Format: int32 */
+            garantipensjonBeloep?: number | null;
+            /** Format: double */
+            garantipensjonSats?: number | null;
+            /** Format: int32 */
+            garantitilleggBeloep?: number | null;
+        };
+        SimuleringV1MaanedligAlderspensjonForKnekkpunkter: {
+            vedGradertUttak?: components["schemas"]["SimuleringV1MaanedligAlderspensjon"] | null;
+            vedHeltUttak?: components["schemas"]["SimuleringV1MaanedligAlderspensjon"] | null;
+            vedNormertPensjonsalder?: components["schemas"]["SimuleringV1MaanedligAlderspensjon"] | null;
+        };
+        SimuleringV1PrivatAfp: {
+            /**
+             * Format: int32
+             * @description Personens alder (år) som informasjonen gjelder for
+             */
+            alderAar: number;
+            /** Format: int32 */
+            aarligBeloep: number;
+            /** Format: int32 */
+            kompensasjonstillegg: number;
+            /** Format: int32 */
+            kronetillegg: number;
+            /** Format: int32 */
+            livsvarig: number;
+            /** Format: int32 */
+            maanedligBeloep?: number | null;
+        };
+        SimuleringV1Problem: {
+            /** @enum {string} */
+            kode: "UGYLDIG_UTTAKSDATO" | "UGYLDIG_UTTAKSGRAD" | "UGYLDIG_SIVILSTATUS" | "UGYLDIG_INNTEKT" | "UGYLDIG_ANTALL_AAR" | "UGYLDIG_PERSONIDENT" | "PERSON_IKKE_FUNNET" | "PERSON_FOR_LAV_ALDER" | "PERSON_FOR_HOEY_ALDER" | "UTILSTREKKELIG_INNTEKT" | "UTILSTREKKELIG_OPPTJENING" | "UTILSTREKKELIG_TRYGDETID" | "ANNEN_KLIENTFEIL" | "INTERN_DATA_INKONSISTENS" | "IMPLEMENTASJONSFEIL" | "TREDJEPARTSFEIL" | "SERVERFEIL";
+            beskrivelse: string;
+        };
+        SimuleringV1Result: {
+            /** @description Alderspensjon for hvert år */
+            alderspensjonListe: components["schemas"]["SimuleringV1Alderspensjon"][];
+            maanedligAlderspensjonVedUttaksendring?: components["schemas"]["SimuleringV1Uttaksbeloep"] | null;
+            maanedligAlderspensjonForKnekkpunkter?: components["schemas"]["SimuleringV1MaanedligAlderspensjonForKnekkpunkter"] | null;
+            /** @description Livsvarig AFP i offentlig sektor for hvert år */
+            livsvarigOffentligAfpListe?: components["schemas"]["SimuleringV1AldersbestemtUtbetaling"][] | null;
+            tidsbegrensetOffentligAfp?: components["schemas"]["SimuleringV1TidsbegrensetOffentligAfp"] | null;
+            /** @description AFP i privat sektor for hvert år */
+            privatAfpListe?: components["schemas"]["SimuleringV1PrivatAfp"][] | null;
+            /** @description Resultatet av vilkårsprøvingen */
+            vilkaarsproevingsresultat: components["schemas"]["SimuleringV1Vilkaarsproevingsresultat"];
+            trygdetid?: components["schemas"]["SimuleringV1Trygdetid"] | null;
+            /** @description Pensjonsgivende inntekter for hvert år */
+            pensjonsgivendeInntektListe?: components["schemas"]["SimuleringV1AarligBeloep"][] | null;
+            problem?: components["schemas"]["SimuleringV1Problem"] | null;
+            serviceberegnetAfp?: components["schemas"]["SimuleringV1ServiceberegnetAfp"] | null;
+        };
+        SimuleringV1ServiceberegnetAfp: {
+            beregnetAfp?: components["schemas"]["SimuleringV1BeregnetAfp"] | null;
+        };
+        SimuleringV1TidsbegrensetOffentligAfp: {
+            /**
+             * Format: int32
+             * @description Personens alder (år) som informasjonen gjelder for
+             */
+            alderAar: number;
+            /**
+             * Format: int32
+             * @description Totalt årlig AFP-beløp
+             */
+            totaltAfpBeloep: number;
+            /**
+             * Format: int32
+             * @description Tidligere arbeidsinntekt
+             */
+            tidligereArbeidsinntekt: number;
+            /**
+             * Format: int32
+             * @description Grunnbeløp
+             */
+            grunnbeloep: number;
+            /**
+             * Format: double
+             * @description Sluttpoengtall
+             */
+            sluttpoengtall: number;
+            /**
+             * Format: int32
+             * @description Antall år trygdetid
+             */
+            trygdetid: number;
+            /**
+             * Format: int32
+             * @description Antall poengår til og med 1991
+             */
+            poengaarTom1991: number;
+            /**
+             * Format: int32
+             * @description Antall poengår fra og med 1992
+             */
+            poengaarFom1992: number;
+            /**
+             * Format: int32
+             * @description Grunnpensjon
+             */
+            grunnpensjon: number;
+            /**
+             * Format: int32
+             * @description Tilleggspensjon
+             */
+            tilleggspensjon: number;
+            /**
+             * Format: int32
+             * @description AFP-tillegg
+             */
+            afpTillegg: number;
+            /**
+             * Format: int32
+             * @description Særtillegg
+             */
+            saertillegg: number;
+            /**
+             * Format: int32
+             * @description AFP-grad
+             */
+            afpGrad: number;
+            /** @description Hvorvidt AFP-ytelsen er avkortet i.h.t. 70-prosentregelen */
+            erAvkortet: boolean;
+        };
+        SimuleringV1Trygdetid: {
+            /** Format: int32 */
+            antallAar: number;
+            erUtilstrekkelig: boolean;
+        };
+        SimuleringV1Uttaksbeloep: {
+            /**
+             * Format: int32
+             * @description Månedlig pensjonsbeløp ved start av gradert uttak
+             */
+            gradertUttakMaanedligBeloep?: number | null;
+            /**
+             * Format: int32
+             * @description Månedlig pensjonsbeløp ved start av helt uttak
+             */
+            heltUttakMaanedligBeloep: number;
+        };
+        SimuleringV1Uttaksparametre: {
+            gradertUttakAlder?: components["schemas"]["SimuleringV1Alder"] | null;
+            /** Format: int32 */
+            uttaksgrad?: number | null;
+            heltUttakAlder: components["schemas"]["SimuleringV1Alder"];
+        };
+        SimuleringV1Vilkaarsproevingsresultat: {
+            erInnvilget: boolean;
+            alternativ?: components["schemas"]["SimuleringV1Uttaksparametre"] | null;
+        };
+        LagreAarligBeloepDto: {
+            /** Format: int32 */
+            aarstall: number;
+            /** Format: int32 */
+            beloep: number;
+        };
+        LagreAfpOffentligLivsvarigSimuleringDto: {
+            vedGradertUttak?: components["schemas"]["LagreLivsvarigOffentligAfpDto"] | null;
+            vedHeltUttak: components["schemas"]["LagreLivsvarigOffentligAfpDto"];
+        };
+        LagreAfpPrivatSimuleringDto: {
+            vedGradertUttak?: components["schemas"]["LagrePrivatAfpDto"] | null;
+            vedHeltUttak: components["schemas"]["LagrePrivatAfpDto"];
+            vedNormertPensjonsalder?: components["schemas"]["LagrePrivatAfpDto"] | null;
+        };
+        LagreAlderDto: {
+            /** Format: int32 */
+            aar: number;
+            /** Format: int32 */
+            maaneder: number;
+        };
+        LagreAlderspensjonDto: {
+            /** Format: int32 */
+            alderAar: number;
+            /** Format: int32 */
+            beloep: number;
+            /** Format: int32 */
+            gjenlevendetillegg?: number | null;
+        };
+        LagreLivsvarigOffentligAfpDto: {
+            /** Format: int32 */
+            alderAar: number;
+            /** Format: int32 */
+            aarligBeloep: number;
+            /** Format: int32 */
+            maanedligBeloep: number;
+        };
+        LagreMaanedligAlderspensjonDto: {
+            /** Format: int32 */
+            beloep: number;
+            /** Format: int32 */
+            inntektspensjonBeloep?: number | null;
+            /** Format: double */
+            delingstall?: number | null;
+            /** Format: int32 */
+            pensjonsbeholdningFoerUttakBeloep?: number | null;
+            /** Format: int32 */
+            pensjonsbeholdningEtterUttakBeloep?: number | null;
+            /** Format: double */
+            sluttpoengtall?: number | null;
+            /** Format: int32 */
+            poengaarTom1991?: number | null;
+            /** Format: int32 */
+            poengaarFom1992?: number | null;
+            /** Format: double */
+            forholdstall?: number | null;
+            /** Format: int32 */
+            grunnpensjonBeloep?: number | null;
+            /** Format: int32 */
+            tilleggspensjonBeloep?: number | null;
+            /** Format: int32 */
+            pensjonstillegg?: number | null;
+            /** Format: int32 */
+            skjermingstillegg?: number | null;
+            /** Format: int32 */
+            kapittel19AndelTeller?: number | null;
+            /** Format: int32 */
+            kapittel19Trygdetid?: number | null;
+            /** Format: int32 */
+            basispensjonBeloep?: number | null;
+            /** Format: int32 */
+            restpensjonBeloep?: number | null;
+            /** Format: int32 */
+            gjenlevendetillegg?: number | null;
+            /** Format: double */
+            minstePensjonsnivaaSats?: number | null;
+            /** Format: int32 */
+            minstePensjonsnivaaBeloep?: number | null;
+            /** Format: int32 */
+            kapittel20AndelTeller?: number | null;
+            /** Format: int32 */
+            kapittel20Trygdetid?: number | null;
+            /** Format: int32 */
+            garantipensjonBeloep?: number | null;
+            /** Format: int32 */
+            garantipensjonsnivaaBeloep?: number | null;
+            /** Format: double */
+            garantipensjonSats?: number | null;
+            /** Format: int32 */
+            garantitilleggBeloep?: number | null;
+            /** Format: int32 */
+            grunnbeloep?: number | null;
+        };
+        LagreMaanedligAlderspensjonForKnekkpunkterDto: {
+            vedGradertUttak?: components["schemas"]["LagreMaanedligAlderspensjonDto"] | null;
+            vedHeltUttak: components["schemas"]["LagreMaanedligAlderspensjonDto"];
+            vedNormertPensjonsalder?: components["schemas"]["LagreMaanedligAlderspensjonDto"] | null;
+        };
+        LagrePrivatAfpDto: {
+            /** Format: int32 */
+            alderAar: number;
+            /** Format: int32 */
+            aarligBeloep: number;
+            /** Format: int32 */
+            kompensasjonstillegg: number;
+            /** Format: int32 */
+            kronetillegg?: number | null;
+            /** Format: int32 */
+            livsvarig: number;
+            /** Format: int32 */
+            maanedligBeloep: number;
+        };
+        LagreSimuleringSpecDtoV1: {
+            alderspensjonListe: components["schemas"]["LagreAlderspensjonDto"][];
+            afpPrivat?: components["schemas"]["LagreAfpPrivatSimuleringDto"] | null;
+            afpOffentligLivsvarig?: components["schemas"]["LagreAfpOffentligLivsvarigSimuleringDto"] | null;
+            afpOffentligTidsbegrenset?: components["schemas"]["LagreTidsbegrensetOffentligAfpDto"] | null;
+            vilkaarsproevingsresultat: components["schemas"]["LagreVilkaarsproevingsresultatDto"];
+            trygdetid?: components["schemas"]["LagreTrygdetidDto"] | null;
+            pensjonsgivendeInntektListe?: components["schemas"]["LagreAarligBeloepDto"][] | null;
+            simuleringsinformasjon?: components["schemas"]["LagreSimuleringsinformasjonDto"] | null;
+            maanedligAlderspensjonForKnekkpunkter?: components["schemas"]["LagreMaanedligAlderspensjonForKnekkpunkterDto"] | null;
+            navEnhetId?: string | null;
+        };
+        LagreSimuleringsinformasjonDto: {
+            gradertUttaksalder?: components["schemas"]["LagreAlderDto"] | null;
+            heltUttaksalder: components["schemas"]["LagreAlderDto"];
+            sivilstatus?: string | null;
+            utenlandsperioder?: components["schemas"]["LagreUtenlandsperiodeDto"][] | null;
+            /** @enum {string} */
+            kull?: "KAP19" | "KAP20" | "OVERGANG";
+            /** @enum {string|null} */
+            normertPensjonsalderPlassering?: "MELLOM_GRADERT_OG_HELT" | "ETTER_HELT" | null;
+        };
+        LagreTidsbegrensetOffentligAfpDto: {
+            /** Format: int32 */
+            alderAar: number;
+            /** Format: int32 */
+            totaltAfpBeloep: number;
+            /** Format: int32 */
+            tidligereArbeidsinntekt: number;
+            /** Format: int32 */
+            grunnbeloep: number;
+            /** Format: double */
+            sluttpoengtall: number;
+            /** Format: int32 */
+            trygdetid: number;
+            /** Format: int32 */
+            poengaarTom1991: number;
+            /** Format: int32 */
+            poengaarFom1992: number;
+            /** Format: int32 */
+            grunnpensjon: number;
+            /** Format: int32 */
+            tilleggspensjon: number;
+            /** Format: int32 */
+            afpTillegg: number;
+            /** Format: int32 */
+            saertillegg: number;
+            /** Format: int32 */
+            afpGrad: number;
+            erAvkortet: boolean;
+        };
+        LagreTrygdetidDto: {
+            /** Format: int32 */
+            antallAar: number;
+            erUtilstrekkelig: boolean;
+        };
+        LagreUtenlandsperiodeDto: {
+            /** Format: date */
+            fom: string;
+            /** Format: date */
+            tom?: string | null;
+            landkode: string;
+            arbeidetUtenlands?: boolean | null;
+        };
+        LagreUttaksparametreDto: {
+            gradertUttakAlder?: components["schemas"]["LagreAlderDto"] | null;
+            /** Format: int32 */
+            uttaksgrad?: number | null;
+            heltUttakAlder: components["schemas"]["LagreAlderDto"];
+        };
+        LagreVilkaarsproevingsresultatDto: {
+            erInnvilget: boolean;
+            alternativ?: components["schemas"]["LagreUttaksparametreDto"] | null;
+        };
+        LagreSimuleringResponseDtoV1: {
+            brevId?: string;
+            sakId?: string;
+            url?: string;
+        };
+        EpsV1EpsSpec: {
+            /** @enum {string} */
+            sivilstatus?: "UNKNOWN" | "UOPPGITT" | "UGIFT" | "GIFT" | "ENKE_ELLER_ENKEMANN" | "SKILT" | "SEPARERT" | "REGISTRERT_PARTNER" | "SEPARERT_PARTNER" | "SKILT_PARTNER" | "GJENLEVENDE_PARTNER" | "SAMBOER";
+            bakgrunn?: string | null;
+        };
+        EpsV1Familierelasjon: {
+            pid?: string | null;
+            /** Format: date */
+            fom?: string | null;
+            /** @enum {string} */
+            relasjonstype: "EKTEFELLE" | "REGISTRERT_PARTNER" | "SAMBOER" | "UKJENT";
+            relasjonPersondata?: components["schemas"]["EpsV1RelasjonPersondata"] | null;
+            problem?: components["schemas"]["EpsV1Problem"] | null;
+        };
+        EpsV1Navn: {
+            fornavn?: string | null;
+            mellomnavn?: string | null;
+            etternavn?: string | null;
+        };
+        EpsV1Problem: {
+            /** @enum {string} */
+            type: "TILGANG_NEKTET";
+            beskrivelse: string;
+        };
+        EpsV1RelasjonPersondata: {
+            /** @enum {string|null} */
+            tilgangsbegrensning?: "FORTROLIG" | "STRENGT_FORTROLIG" | "STRENGT_FORTROLIG_UTLAND" | "UNKNOWN" | null;
+            navn?: components["schemas"]["EpsV1Navn"] | null;
+            /** Format: date */
+            foedselsdato?: string | null;
+            /** Format: date */
+            doedsdato?: string | null;
+            statsborgerskap?: string | null;
+        };
+        PersonV7Alder: {
+            /** Format: int32 */
+            aar: number;
+            /** Format: int32 */
+            maaneder: number;
+        };
+        PersonV7Pensjonsaldre: {
+            normertPensjoneringsalder: components["schemas"]["PersonV7Alder"];
+            nedreAldersgrense: components["schemas"]["PersonV7Alder"];
+            oevreAldersgrense: components["schemas"]["PersonV7Alder"];
+        };
+        PersonV7Result: {
+            navn: string;
+            fornavn: string;
+            /** Format: date */
+            foedselsdato: string;
+            /** @enum {string} */
+            sivilstatus: "UNKNOWN" | "UOPPGITT" | "UGIFT" | "GIFT" | "ENKE_ELLER_ENKEMANN" | "SKILT" | "SEPARERT" | "REGISTRERT_PARTNER" | "SEPARERT_PARTNER" | "SKILT_PARTNER" | "GJENLEVENDE_PARTNER" | "SAMBOER";
+            pensjoneringAldre: components["schemas"]["PersonV7Pensjonsaldre"];
+        };
+        PersonAlderV6: {
+            /** Format: int32 */
+            aar: number;
+            /** Format: int32 */
+            maaneder: number;
+        };
+        PersonPensjonsaldreV6: {
+            normertPensjoneringsalder: components["schemas"]["PersonAlderV6"];
+            nedreAldersgrense: components["schemas"]["PersonAlderV6"];
+            oevreAldersgrense: components["schemas"]["PersonAlderV6"];
+        };
+        PersonResultV6: {
+            navn: string;
+            fornavn: string;
+            /** Format: date */
+            foedselsdato: string;
+            /** @enum {string} */
+            sivilstand: "UNKNOWN" | "UOPPGITT" | "UGIFT" | "GIFT" | "ENKE_ELLER_ENKEMANN" | "SKILT" | "SEPARERT" | "REGISTRERT_PARTNER" | "SEPARERT_PARTNER" | "SKILT_PARTNER" | "GJENLEVENDE_PARTNER";
+            pensjoneringAldre: components["schemas"]["PersonPensjonsaldreV6"];
         };
         AlderspensjonDetaljerV4: {
             /** Format: int32 */
             grad: number;
             /** Format: date */
             fom: string;
-            sisteUtbetaling?: components["schemas"]["UtbetalingV4"];
+            /** Format: date */
+            uttaksgradFom: string;
+            sisteUtbetaling?: components["schemas"]["UtbetalingV4"] | null;
             /** @enum {string} */
             sivilstand: "UNKNOWN" | "UOPPGITT" | "UGIFT" | "GIFT" | "ENKE_ELLER_ENKEMANN" | "SKILT" | "SEPARERT" | "REGISTRERT_PARTNER" | "SEPARERT_PARTNER" | "SKILT_PARTNER" | "GJENLEVENDE_PARTNER" | "SAMBOER";
         };
@@ -1113,11 +1925,13 @@ export interface components {
             fom: string;
         };
         LoependeVedtakV4: {
-            alderspensjon?: components["schemas"]["AlderspensjonDetaljerV4"];
-            fremtidigAlderspensjon?: components["schemas"]["FremtidigAlderspensjonDetaljerV4"];
+            harLoependeVedtak: boolean;
+            alderspensjon?: components["schemas"]["AlderspensjonDetaljerV4"] | null;
+            fremtidigAlderspensjon?: components["schemas"]["FremtidigAlderspensjonDetaljerV4"] | null;
             ufoeretrygd: components["schemas"]["UfoeretrygdDetaljerV4"];
-            afpPrivat?: components["schemas"]["LoependeFraV4"];
-            afpOffentlig?: components["schemas"]["LoependeFraV4"];
+            afpPrivat?: components["schemas"]["LoependeFraV4"] | null;
+            afpOffentlig?: components["schemas"]["LoependeFraV4"] | null;
+            pre2025OffentligAfp?: components["schemas"]["LoependeFraV4"] | null;
         };
         UfoeretrygdDetaljerV4: {
             /** Format: int32 */
@@ -1128,91 +1942,128 @@ export interface components {
             /** Format: date */
             utbetalingsdato: string;
         };
-        PersonAlderV4: {
+        LivsvarigOffentligAfpResultV3: {
+            afpInnvilget?: boolean | null;
+            maanedligBeloepListe?: components["schemas"]["MaanedligBeloepV3"][];
+            /** Format: date */
+            virkningFom?: string | null;
             /** Format: int32 */
-            aar: number;
+            sistBenyttetGrunnbeloep?: number | null;
+        };
+        MaanedligBeloepV3: {
+            /** Format: date */
+            virkningFom?: string | null;
             /** Format: int32 */
-            maaneder: number;
+            beloep?: number | null;
         };
-        PersonPensjoneringAldreV4: {
-            normertPensjoneringsalder: components["schemas"]["PersonAlderV4"];
-            nedreAldersgrense: components["schemas"]["PersonAlderV4"];
-        };
-        PersonResultV4: {
-            navn: string;
+        LivsvarigOffentligAfpResultV2: {
+            afpStatus?: boolean | null;
             /** Format: date */
-            foedselsdato: string;
-            /** @enum {string} */
-            sivilstand: "UNKNOWN" | "UOPPGITT" | "UGIFT" | "GIFT" | "ENKE_ELLER_ENKEMANN" | "SKILT" | "SEPARERT" | "REGISTRERT_PARTNER" | "SEPARERT_PARTNER" | "SKILT_PARTNER" | "GJENLEVENDE_PARTNER";
-            pensjoneringAldre: components["schemas"]["PersonPensjoneringAldreV4"];
-        };
-        AlderspensjonDetaljerV3: {
+            virkningFom?: string | null;
             /** Format: int32 */
-            grad: number;
-            /** Format: date */
-            fom: string;
-            sisteUtbetaling?: components["schemas"]["UtbetalingV3"];
-            /** @enum {string} */
-            sivilstand: "UNKNOWN" | "UOPPGITT" | "UGIFT" | "GIFT" | "ENKE_ELLER_ENKEMANN" | "SKILT" | "SEPARERT" | "REGISTRERT_PARTNER" | "SEPARERT_PARTNER" | "SKILT_PARTNER" | "GJENLEVENDE_PARTNER" | "SAMBOER";
-        };
-        LoependeFraV3: {
-            /** Format: date */
-            fom: string;
-        };
-        LoependeVedtakV3: {
-            alderspensjon?: components["schemas"]["AlderspensjonDetaljerV3"];
-            harFremtidigLoependeVedtak: boolean;
-            ufoeretrygd: components["schemas"]["UfoeretrygdDetaljerV3"];
-            afpPrivat?: components["schemas"]["LoependeFraV3"];
-            afpOffentlig?: components["schemas"]["LoependeFraV3"];
-        };
-        UfoeretrygdDetaljerV3: {
+            maanedligBeloep?: number | null;
             /** Format: int32 */
-            grad: number;
-        };
-        UtbetalingV3: {
-            beloep: number;
-            /** Format: date */
-            utbetalingsdato: string;
-        };
-        AlderspensjonDetaljerV2: {
-            /** Format: int32 */
-            grad: number;
-            /** Format: date */
-            fom: string;
-            sisteUtbetaling?: components["schemas"]["UtbetalingV2"];
-        };
-        LoependeFraV2: {
-            /** Format: date */
-            fom: string;
-        };
-        LoependeVedtakV2: {
-            alderspensjon?: components["schemas"]["AlderspensjonDetaljerV2"];
-            harFremtidigLoependeVedtak: boolean;
-            ufoeretrygd: components["schemas"]["UfoeretrygdDetaljerV2"];
-            afpPrivat?: components["schemas"]["LoependeFraV2"];
-            afpOffentlig?: components["schemas"]["LoependeFraV2"];
-        };
-        UfoeretrygdDetaljerV2: {
-            /** Format: int32 */
-            grad: number;
-        };
-        UtbetalingV2: {
-            beloep: number;
-            /** Format: date */
-            utbetalingsdato: string;
-        };
-        PersonV2: {
-            navn: string;
-            /** Format: date */
-            foedselsdato: string;
-            /** @enum {string} */
-            sivilstand: "UNKNOWN" | "UOPPGITT" | "UGIFT" | "GIFT" | "ENKE_ELLER_ENKEMANN" | "SKILT" | "SEPARERT" | "REGISTRERT_PARTNER" | "SEPARERT_PARTNER" | "SKILT_PARTNER" | "GJENLEVENDE_PARTNER";
+            sistBenyttetGrunnbeloep?: number | null;
         };
         EkskluderingStatusV2: {
             ekskludert: boolean;
             /** @enum {string} */
             aarsak: "NONE" | "ER_APOTEKER";
+        };
+        VedtakV1Alderspensjonsuttak: {
+            /**
+             * Format: int32
+             * @description Uttaksgrad (prosent) for alderspensjonen
+             */
+            grad: number;
+            /**
+             * Format: date
+             * @description Startdato (fra og med) for alderspensjonen
+             */
+            fom: string;
+        };
+        VedtakV1InformasjonOmAvdoed: {
+            /** @description Avdødes person-ID */
+            pid?: string | null;
+            /**
+             * Format: date
+             * @description Dato for dødsfallet
+             */
+            doedsdato?: string | null;
+            /**
+             * Format: date
+             * @description Virkningsdato (fra og med) for avdødes første vedtak om alderspensjon
+             */
+            foersteAlderspensjonVirkningsdato?: string | null;
+            /** @description Hvorvidt avdødes årlige pensjonsgivende inntekt var minst 1G (grunnbeløpet) */
+            aarligPensjonsgivendeInntektErMinst1G?: boolean | null;
+            /** @description Hvorvidt avdøde hadde tilstrekkelig medlemskap i folketrygden */
+            harTilstrekkeligMedlemskapIFolketrygden?: boolean | null;
+            /**
+             * Format: int32
+             * @description Antall år som avdøde hadde oppholdt seg i utlandet
+             */
+            antallAarUtenlands?: number | null;
+            /** @description Hvorvidt avdøde var flyktning */
+            erFlyktning?: boolean | null;
+        };
+        VedtakV1LoependeAlderspensjon: {
+            /**
+             * Format: int32
+             * @description Uttaksgrad (prosent) for alderspensjonen
+             */
+            grad: number;
+            /**
+             * Format: date
+             * @description Startdato (fra og med) for alderspensjonen
+             */
+            fom: string;
+            /**
+             * Format: date
+             * @description Startdato (fra og med) for uttaksgraden
+             */
+            uttaksgradFom: string;
+            sisteUtbetaling?: components["schemas"]["VedtakV1Utbetaling"] | null;
+            /**
+             * @description Sivilstatus
+             * @enum {string}
+             */
+            sivilstatus: "UNKNOWN" | "UOPPGITT" | "UGIFT" | "GIFT" | "ENKE_ELLER_ENKEMANN" | "SKILT" | "SEPARERT" | "REGISTRERT_PARTNER" | "SEPARERT_PARTNER" | "SKILT_PARTNER" | "GJENLEVENDE_PARTNER" | "SAMBOER";
+            /** @description Hvorvidt personen har rett til gjenlevendeytelse */
+            harGjenlevenderett: boolean;
+            /** @description Hvorvidt personen har opphold i utlandet */
+            harUtenlandsopphold: boolean;
+        };
+        VedtakV1Samling: {
+            /** @description Hvorvidt personen har løpende eller fremtidig vedtak */
+            harVedtak: boolean;
+            loependeAlderspensjon?: components["schemas"]["VedtakV1LoependeAlderspensjon"] | null;
+            fremtidigAlderspensjon?: components["schemas"]["VedtakV1Alderspensjonsuttak"] | null;
+            /**
+             * Format: int32
+             * @description Grad av uføretrygd (0-100)
+             */
+            ufoeretrygdgrad?: number | null;
+            /**
+             * Format: date
+             * @description Startdato (fra og med) for AFP i privat sektor
+             */
+            privatAfpFom?: string | null;
+            /**
+             * Format: date
+             * @description Startdato (fra og med) for tidsbegrenset AFP i offentlig sektor ('gammel ordning')
+             */
+            tidsbegrensetOffentligAfpFom?: string | null;
+            avdoed?: components["schemas"]["VedtakV1InformasjonOmAvdoed"] | null;
+        };
+        VedtakV1Utbetaling: {
+            /** @description Beløp utbetalt */
+            beloep: number;
+            /**
+             * Format: date
+             * @description Dato for utbetalingen
+             */
+            utbetalingsdato: string;
         };
         UfoeregradDto: {
             /** Format: int32 */
@@ -1226,10 +2077,15 @@ export interface components {
         };
         LandInfo: {
             landkode: string;
-            kravOmArbeid?: boolean;
+            kravOmArbeid?: boolean | null;
             bokmaalNavn: string;
             nynorskNavn: string;
             engelskNavn: string;
+        };
+        ApotekerStatusV1: {
+            apoteker: boolean;
+            /** @enum {string} */
+            aarsak: "NONE" | "ER_APOTEKER";
         };
         EkskluderingStatusV1: {
             ekskludert: boolean;
@@ -1247,6 +2103,43 @@ export interface components {
         };
         SakDto: {
             harUfoeretrygdEllerGjenlevendeytelse: boolean;
+        };
+        EpsV1SivilstatusResult: {
+            /** @enum {string} */
+            sivilstatus: "UNKNOWN" | "UOPPGITT" | "UGIFT" | "GIFT" | "ENKE_ELLER_ENKEMANN" | "SKILT" | "SEPARERT" | "REGISTRERT_PARTNER" | "SEPARERT_PARTNER" | "SKILT_PARTNER" | "GJENLEVENDE_PARTNER" | "SAMBOER";
+        };
+        PersonInternV1Alder: {
+            /** Format: int32 */
+            aar: number;
+            /** Format: int32 */
+            maaneder: number;
+        };
+        PersonInternV1Pensjonsaldre: {
+            normertPensjoneringsalder: components["schemas"]["PersonInternV1Alder"];
+            nedreAldersgrense: components["schemas"]["PersonInternV1Alder"];
+            oevreAldersgrense: components["schemas"]["PersonInternV1Alder"];
+        };
+        PersonInternV1Person: {
+            navn: string;
+            /** Format: date */
+            foedselsdato: string;
+            /** @enum {string} */
+            sivilstatus: "UNKNOWN" | "UOPPGITT" | "UGIFT" | "GIFT" | "ENKE_ELLER_ENKEMANN" | "SKILT" | "SEPARERT" | "REGISTRERT_PARTNER" | "SEPARERT_PARTNER" | "SKILT_PARTNER" | "GJENLEVENDE_PARTNER" | "SAMBOER";
+            pensjoneringAldre: components["schemas"]["PersonInternV1Pensjonsaldre"];
+        };
+        AnsattEnhetV1Problem: {
+            /** @enum {string} */
+            kode: "ANSATT_IKKE_FUNNET" | "ANNEN_KLIENTFEIL" | "SERVERFEIL";
+            beskrivelse: string;
+        };
+        AnsattEnhetV1Result: {
+            /** @description Liste over enheter (tjenestekontor) */
+            enhetListe: components["schemas"]["AnsattEnhetV1Tjenestekontor"][];
+            problem?: components["schemas"]["AnsattEnhetV1Problem"] | null;
+        };
+        AnsattEnhetV1Tjenestekontor: {
+            id: string;
+            navn: string;
         };
         InntektDto: {
             /** Format: int32 */
@@ -1266,7 +2159,7 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
-    simulerAlderspensjonV8: {
+    simulerAlderspensjonV9: {
         parameters: {
             query?: never;
             header?: never;
@@ -1275,7 +2168,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["PersonligSimuleringSpecV8"];
+                "application/json": components["schemas"]["PersonligSimuleringSpecV9"];
             };
         };
         responses: {
@@ -1285,10 +2178,50 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "*/*": components["schemas"]["PersonligSimuleringResultV8"];
+                    "*/*": components["schemas"]["PersonligSimuleringResultV9"];
                 };
             };
             /** @description Simulering kunne ikke utføres av tekniske årsaker */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /** @example {
+                     *       "timestamp": "2023-09-12T10:37:47.056+00:00",
+                     *       "status": 503,
+                     *       "error": "Service Unavailable",
+                     *       "message": "En feil inntraff",
+                     *       "path": "/api/ressurs"
+                     *     } */
+                    "*/*": unknown;
+                };
+            };
+        };
+    };
+    finnTidligsteHelUttaksalderV3: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UttaksalderSpecV3"];
+            };
+        };
+        responses: {
+            /** @description Søk etter uttaksalder utført. I resultatet er verdi av 'maaneder' 0..11. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["UttaksalderResultV3"];
+                };
+            };
+            /** @description Søk etter uttaksalder kunne ikke utføres av tekniske årsaker */
             503: {
                 headers: {
                     [name: string]: unknown;
@@ -1346,39 +2279,6 @@ export interface operations {
             };
         };
     };
-    finnTidligsteHelUttaksalderV2: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UttaksalderSpecV2"];
-            };
-        };
-        responses: {
-            /** @description Søk etter uttaksalder utført. I resultatet er verdi av 'maaneder' 0..11. */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["UttaksalderResultV2"];
-                };
-            };
-            /** @description Søk etter uttaksalder kunne ikke utføres av tekniske årsaker */
-            503: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["UttaksalderError"];
-                };
-            };
-        };
-    };
     simulerOffentligTjenestepensjonV2: {
         parameters: {
             query?: never;
@@ -1388,7 +2288,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["IngressSimuleringOffentligTjenestepensjonSpecV2"];
+                "application/json": components["schemas"]["SimuleringOffentligTjenestepensjonSpecV2"];
             };
         };
         responses: {
@@ -1398,12 +2298,12 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "*/*": components["schemas"]["OffentligTjenestepensjonSimuleringsresultatDtoV2"];
+                    "*/*": components["schemas"]["OffentligTjenestepensjonSimuleringResultV2"];
                 };
             };
         };
     };
-    fetchAvtalerV2: {
+    simulerOffentligTjenestepensjonFoer1963V1: {
         parameters: {
             query?: never;
             header?: never;
@@ -1412,80 +2312,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["PensjonsavtaleSpecV2"];
-            };
-        };
-        responses: {
-            /** @description Henting av pensjonsavtaler utført. I respons er verdi av 'maaneder' 0..11. */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["PensjonsavtaleResultV2"];
-                };
-            };
-            /** @description Henting av pensjonsavtaler kunne ikke utføres av tekniske årsaker */
-            503: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": unknown;
-                };
-            };
-        };
-    };
-    finnTidligsteHelUttaksalderV1: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["IngressUttaksalderSpecForHeltUttakV1"];
-            };
-        };
-        responses: {
-            /** @description Søk etter uttaksalder utført. I resultatet er verdi av 'maaneder' 0..11. */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["AlderDto"];
-                };
-            };
-            /** @description Søk etter uttaksalder kunne ikke utføres av tekniske årsaker */
-            503: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /** @example {
-                     *       "timestamp": "2023-09-12T10:37:47.056+00:00",
-                     *       "status": 503,
-                     *       "error": "Service Unavailable",
-                     *       "message": "En feil inntraff",
-                     *       "path": "/api/ressurs"
-                     *     } */
-                    "*/*": unknown;
-                };
-            };
-        };
-    };
-    simulerOffentligTjenestepensjonV1: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["IngressSimuleringOffentligTjenestepensjonSpecV1"];
+                "application/json": components["schemas"]["SimuleringOffentligTjenestepensjonFoer1963SpecV1"];
             };
         };
         responses: {
@@ -1495,7 +2322,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "*/*": components["schemas"]["OffentligTjenestepensjonSimuleringsresultatDtoV1"];
+                    "*/*": components["schemas"]["OffentligTjenestepensjonSimuleringFoer1963ResultV1"];
                 };
             };
         };
@@ -1523,6 +2350,46 @@ export interface operations {
                 };
             };
             /** @description Kryptering kunne ikke utføres av tekniske årsaker */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /** @example {
+                     *       "timestamp": "2023-09-12T10:37:47.056+00:00",
+                     *       "status": 503,
+                     *       "error": "Service Unavailable",
+                     *       "message": "En feil inntraff",
+                     *       "path": "/api/ressurs"
+                     *     } */
+                    "*/*": unknown;
+                };
+            };
+        };
+    };
+    decrypt: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": string;
+            };
+        };
+        responses: {
+            /** @description Dekryptering utført */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": string;
+                };
+            };
+            /** @description Dekryptering kunne ikke utføres av tekniske årsaker */
             503: {
                 headers: {
                     [name: string]: unknown;
@@ -1573,7 +2440,7 @@ export interface operations {
             };
         };
     };
-    aldersgrenserV1: {
+    simulerPensjon: {
         parameters: {
             query?: never;
             header?: never;
@@ -1582,25 +2449,293 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["AldersgrenseSpec"];
+                "application/json": components["schemas"]["SimuleringV1Spec"];
             };
         };
         responses: {
-            /** @description Henting av aldersgrenser utført. */
+            /** @description Simulering utført */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "*/*": components["schemas"]["AldersgrenseResultV1"];
+                    "*/*": components["schemas"]["SimuleringV1Result"];
                 };
             };
-            /** @description Henting av aldersgrenser kunne ikke utføres av tekniske årsaker. */
+            /** @description Simulering kunne ikke utføres pga. uakseptable inndata. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["SimuleringV1Result"];
+                };
+            };
+            /** @description Simulering kunne ikke utføres pga. manglende/feilaktig autentisering. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["SimuleringV1Result"];
+                };
+            };
+            /** @description Simulering kunne ikke utføres pga. manglende tilgang til tjenesten. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["SimuleringV1Result"];
+                };
+            };
+            /** @description Simulering kunne ikke utføres fordi angitt person ikke finnes i systemet. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["SimuleringV1Result"];
+                };
+            };
+            /** @description Simulering kunne ikke utføres pga. feil i systemet. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["SimuleringV1Result"];
+                };
+            };
+        };
+    };
+    lagreSimuleringV1: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LagreSimuleringSpecDtoV1"];
+            };
+        };
+        responses: {
+            /** @description Lagring utført */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["LagreSimuleringResponseDtoV1"];
+                };
+            };
+            /** @description Lagring kunne ikke utføres av tekniske årsaker */
             503: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
+                    "*/*": components["schemas"]["LagreSimuleringResponseDtoV1"];
+                };
+            };
+        };
+    };
+    nyligsteEps: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EpsV1EpsSpec"];
+            };
+        };
+        responses: {
+            /** @description Henting av EPS utført. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["EpsV1Familierelasjon"];
+                };
+            };
+            /** @description Henting av EPS kunne ikke utføres av tekniske årsaker. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /** @example {
+                     *       "timestamp": "2023-09-12T10:37:47.056+00:00",
+                     *       "status": 503,
+                     *       "error": "Service Unavailable",
+                     *       "message": "En feil inntraff",
+                     *       "path": "/api/ressurs"
+                     *     } */
+                    "*/*": unknown;
+                };
+            };
+        };
+    };
+    simulerPensjon_1: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SimuleringV1Spec"];
+            };
+        };
+        responses: {
+            /** @description Simulering utført */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["SimuleringV1Result"];
+                };
+            };
+            /** @description Simulering kunne ikke utføres pga. uakseptable inndata. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["SimuleringV1Result"];
+                };
+            };
+            /** @description Simulering kunne ikke utføres pga. manglende/feilaktig autentisering. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["SimuleringV1Result"];
+                };
+            };
+            /** @description Simulering kunne ikke utføres pga. manglende tilgang til tjenesten. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["SimuleringV1Result"];
+                };
+            };
+            /** @description Simulering kunne ikke utføres fordi angitt person ikke finnes i systemet. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["SimuleringV1Result"];
+                };
+            };
+            /** @description Simulering kunne ikke utføres pga. feil i systemet. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["SimuleringV1Result"];
+                };
+            };
+        };
+    };
+    person: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Henting av personinformasjon utført. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["PersonV7Result"];
+                };
+            };
+            /** @description Personen ble ikke funnet. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["PersonV7Result"];
+                };
+            };
+            /** @description Henting av personinformasjon kunne ikke utføres av tekniske årsaker. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /** @example {
+                     *       "timestamp": "2023-09-12T10:37:47.056+00:00",
+                     *       "status": 503,
+                     *       "error": "Service Unavailable",
+                     *       "message": "En feil inntraff",
+                     *       "path": "/api/ressurs"
+                     *     } */
+                    "*/*": unknown;
+                };
+            };
+        };
+    };
+    personV6: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Henting av personinformasjon utført. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["PersonResultV6"];
+                };
+            };
+            /** @description Personen ble ikke funnet. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["PersonResultV6"];
+                };
+            };
+            /** @description Henting av personinformasjon kunne ikke utføres av tekniske årsaker. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /** @example {
+                     *       "timestamp": "2023-09-12T10:37:47.056+00:00",
+                     *       "status": 503,
+                     *       "error": "Service Unavailable",
+                     *       "message": "En feil inntraff",
+                     *       "path": "/api/ressurs"
+                     *     } */
                     "*/*": unknown;
                 };
             };
@@ -1630,44 +2765,6 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "*/*": unknown;
-                };
-            };
-        };
-    };
-    personV4: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Henting av personinformasjon utført. */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["PersonResultV4"];
-                };
-            };
-            /** @description Personen ble ikke funnet. */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["PersonResultV4"];
-                };
-            };
-            /** @description Henting av personinformasjon kunne ikke utføres av tekniske årsaker. */
-            503: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
                     /** @example {
                      *       "timestamp": "2023-09-12T10:37:47.056+00:00",
                      *       "status": 503,
@@ -1680,7 +2777,7 @@ export interface operations {
             };
         };
     };
-    hentLoependeVedtakV3: {
+    hentLivsvarigOffentligAfpDetaljerV3: {
         parameters: {
             query?: never;
             header?: never;
@@ -1689,34 +2786,18 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Henting av løpende vedtak utført */
+            /** @description OK */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "*/*": components["schemas"]["LoependeVedtakV3"];
-                };
-            };
-            /** @description Henting av løpende vedtak kunne ikke utføres av tekniske årsaker */
-            503: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /** @example {
-                     *       "timestamp": "2023-09-12T10:37:47.056+00:00",
-                     *       "status": 503,
-                     *       "error": "Service Unavailable",
-                     *       "message": "En feil inntraff",
-                     *       "path": "/api/ressurs"
-                     *     } */
-                    "*/*": unknown;
+                    "*/*": components["schemas"]["LivsvarigOffentligAfpResultV3"];
                 };
             };
         };
     };
-    hentLoependeVedtakV2: {
+    hentLivsvarigOffentligAfpDetaljer: {
         parameters: {
             query?: never;
             header?: never;
@@ -1725,74 +2806,13 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Henting av løpende vedtak utført */
+            /** @description OK */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "*/*": components["schemas"]["LoependeVedtakV2"];
-                };
-            };
-            /** @description Henting av løpende vedtak kunne ikke utføres av tekniske årsaker */
-            503: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /** @example {
-                     *       "timestamp": "2023-09-12T10:37:47.056+00:00",
-                     *       "status": 503,
-                     *       "error": "Service Unavailable",
-                     *       "message": "En feil inntraff",
-                     *       "path": "/api/ressurs"
-                     *     } */
-                    "*/*": unknown;
-                };
-            };
-        };
-    };
-    personV2: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Henting av personinformasjon utført. */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["PersonV2"];
-                };
-            };
-            /** @description Personen ble ikke funnet. */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "*/*": components["schemas"]["PersonV2"];
-                };
-            };
-            /** @description Henting av personinformasjon kunne ikke utføres av tekniske årsaker. */
-            503: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /** @example {
-                     *       "timestamp": "2023-09-12T10:37:47.056+00:00",
-                     *       "status": 503,
-                     *       "error": "Service Unavailable",
-                     *       "message": "En feil inntraff",
-                     *       "path": "/api/ressurs"
-                     *     } */
-                    "*/*": unknown;
+                    "*/*": components["schemas"]["LivsvarigOffentligAfpResultV2"];
                 };
             };
         };
@@ -1829,6 +2849,71 @@ export interface operations {
                      *       "path": "/api/ressurs"
                      *     } */
                     "*/*": unknown;
+                };
+            };
+        };
+    };
+    hentVedtak: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Henting av vedtak utført. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["VedtakV1Samling"];
+                };
+            };
+            /** @description Tjenesten kunne ikke utføres pga. uakseptable inndata. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["VedtakV1Samling"];
+                };
+            };
+            /** @description Tjenesten kunne ikke utføres pga. manglende/feilaktig autentisering. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["VedtakV1Samling"];
+                };
+            };
+            /** @description Tjenesten kunne ikke utføres pga. manglende tilgang til tjenesten. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["VedtakV1Samling"];
+                };
+            };
+            /** @description Tjenesten kunne ikke utføres fordi angitt person ikke finnes i systemet. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["VedtakV1Samling"];
+                };
+            };
+            /** @description Tjenesten kunne ikke utføres pga. feil i systemet. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["VedtakV1Samling"];
                 };
             };
         };
@@ -1944,6 +3029,42 @@ export interface operations {
                 };
             };
             /** @description Henting av land-liste kunne ikke utføres av tekniske årsaker. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /** @example {
+                     *       "timestamp": "2023-09-12T10:37:47.056+00:00",
+                     *       "status": 503,
+                     *       "error": "Service Unavailable",
+                     *       "message": "En feil inntraff",
+                     *       "path": "/api/ressurs"
+                     *     } */
+                    "*/*": unknown;
+                };
+            };
+        };
+    };
+    erApotekerV1: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Sjekking av apoteker utført */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["ApotekerStatusV1"];
+                };
+            };
+            /** @description Sjekking av apoteker kunne ikke utføres av tekniske årsaker */
             503: {
                 headers: {
                     [name: string]: unknown;
@@ -2105,6 +3226,143 @@ export interface operations {
                      *       "path": "/api/ressurs"
                      *     } */
                     "*/*": unknown;
+                };
+            };
+        };
+    };
+    naavaerendeSivilstatus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Henting av sivilstatus utført. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["EpsV1SivilstatusResult"];
+                };
+            };
+            /** @description Henting av sivilstatus kunne ikke utføres av tekniske årsaker. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /** @example {
+                     *       "timestamp": "2023-09-12T10:37:47.056+00:00",
+                     *       "status": 503,
+                     *       "error": "Service Unavailable",
+                     *       "message": "En feil inntraff",
+                     *       "path": "/api/ressurs"
+                     *     } */
+                    "*/*": unknown;
+                };
+            };
+        };
+    };
+    personV1: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Henting av personinformasjon utført. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["PersonInternV1Person"];
+                };
+            };
+            /** @description Personen ble ikke funnet. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["PersonInternV1Person"];
+                };
+            };
+            /** @description Henting av personinformasjon kunne ikke utføres av tekniske årsaker. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /** @example {
+                     *       "timestamp": "2023-09-12T10:37:47.056+00:00",
+                     *       "status": 503,
+                     *       "error": "Service Unavailable",
+                     *       "message": "En feil inntraff",
+                     *       "path": "/api/ressurs"
+                     *     } */
+                    "*/*": unknown;
+                };
+            };
+        };
+    };
+    tjenestekontorEnhetListe: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Henting av enheter utført. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["AnsattEnhetV1Result"];
+                };
+            };
+            /** @description Henting av enheter kunne ikke utføres pga. manglende/feilaktig autentisering. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["AnsattEnhetV1Result"];
+                };
+            };
+            /** @description Henting av enheter kunne ikke utføres pga. manglende tilgang til tjenesten eller personen. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["AnsattEnhetV1Result"];
+                };
+            };
+            /** @description Henting av enheter kunne ikke utføres fordi angitt ansatt-ID ikke finnes i systemet. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["AnsattEnhetV1Result"];
+                };
+            };
+            /** @description Henting av enheter kunne ikke utføres pga. feil i systemet. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "*/*": components["schemas"]["AnsattEnhetV1Result"];
                 };
             };
         };


### PR DESCRIPTION
This pull request streamlines the process for generating and formatting OpenAPI backend types by moving these steps from CI workflows to a local pre-push Git hook. This ensures that the generated `schema.d.ts` file is always up-to-date and committed before code is pushed, reducing CI complexity and preventing out-of-sync type definitions.

**Type generation and formatting workflow changes:**

* Removed the steps for fetching and formatting OpenAPI backend types from the GitHub Actions workflows (`.github/workflows/check-pull-request.yml` and `.github/workflows/deploy.yml`), simplifying the CI process. [[1]](diffhunk://#diff-d57a8f8916c02e1b4c666d60987fd7a9cf5525433bd8c01c32a51817285153d2L34-L50) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L53-L58)
* Added a `generate-types` script to `package.json` to fetch and format the OpenAPI types in one command.

**Developer workflow improvements:**

* Introduced a pre-push Git hook (`.husky/pre-push`) that runs the `generate-types` script and checks for changes in `src/types/schema.d.ts`, preventing pushes if the types are outdated and not committed.